### PR TITLE
Fix python plugins, add CLBOSS, and fix port to JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/*.rs.bk
 c-lightning.s9pk
 image.tar
-scripts/embassy.js
+scripts/embassy.jstmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.rs.bk
 c-lightning.s9pk
 image.tar
-scripts/embassy.jstmp/
+scripts/embassy.js
+tmp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "c-lightning-REST"]
 	path = c-lightning-REST
 	url = https://github.com/Ride-The-Lightning/c-lightning-REST
+[submodule "clboss"]
+	path = clboss
+	url = https://github.com/ZmnSCPxj/clboss

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,94 +1,232 @@
-FROM alpine:3.12 as bitcoin-core
+# FROM debian:bullseye-slim as bitcoin-core
 
-RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
-RUN apk --no-cache add autoconf
-RUN apk --no-cache add automake
-RUN apk --no-cache add boost-dev
-RUN apk --no-cache add build-base
-RUN apk --no-cache add chrpath
-RUN apk --no-cache add file
-RUN apk --no-cache add gnupg
-RUN apk --no-cache add libevent-dev
-RUN apk --no-cache add libressl
-RUN apk --no-cache add libtool
-RUN apk --no-cache add linux-headers
-RUN apk --no-cache add zeromq-dev
-RUN set -ex \
-    && for key in \
-    90C8019E36C2E964 \
-    ; do \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-    done
+# LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+#   maintainer.1="Pedro Branco (@pedrobranco)" \
+#   maintainer.2="Rui Marinho (@ruimarinho)"
 
-ARG BITCOIN_VERSION
-RUN test -n "$BITCOIN_VERSION"
+# RUN useradd -r bitcoin \
+#   && apt-get update -y \
+#   && apt-get install -y curl gnupg gosu \
+#   && apt-get clean \
+#   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+# ARG TARGETPLATFORM
+# ENV BITCOIN_VERSION=23.0
+# ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+# ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
-RUN gpg --verify SHA256SUMS.asc
-RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
-RUN tar -xzf *.tar.gz
-
-WORKDIR /bitcoin-${BITCOIN_VERSION}
-
-RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
-RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
-RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
-RUN ./autogen.sh
-RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
-    --prefix=${BITCOIN_PREFIX} \
-    --mandir=/usr/share/man \
-    --disable-tests \
-    --disable-bench \
-    --disable-ccache \
-    --with-gui=no \
-    --disable-wallet \
-    --enable-util-cli
-RUN make -j$(($(nproc) - 1))
-RUN strip ./src/bitcoin-cli
+# RUN set -ex \
+#   && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
+#   && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
+#   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
+#   && for key in \
+#     152812300785C96444D3334D17565732E08E5E41 \
+#     0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
+#     590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
+#     28F5900B1BB5D1A4B6B6D1A9ED357015286A333D \
+#     637DB1E23370F84AFF88CCE03152347D07DA627C \
+#     CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
+#     F4FC70F07310028424EFC20A8E4256593F177720 \
+#     D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
+#     287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
+#     F9A8737BF4FF5C89C903DF31DD78544CF91B1514 \
+#     9DEAE0DC7063249FB05474681E4AED62986CD25D \
+#     E463A93F5F3117EEDE6C7316BD02942421F4889F \
+#     9D3CC86A72F8494342EA5FD10A41BDC3F4FAFF1C \
+#     4DAF18FE948E7A965B30F9457E296D555E7F63A7 \
+#     28E72909F1717FE9607754F8A7BEB2621678D37D \
+#     74E2DEF5D77260B98BC19438099BAD163C70FBFA \
+#   ; do \
+#       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+#       gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
+#       gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+#       gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+#       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+#       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+#     done \
+#   && curl -SL https://raw.githubusercontent.com/Kvaciral/kvaciral/main/kvaciral.asc | gpg --import \
+#   && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
+#   && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+#   && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+#   && gpg --verify SHA256SUMS.asc SHA256SUMS \
+#   && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
+#   && tar -xzf *.tar.gz -C /opt \
+#   && rm *.tar.gz *.asc \
+#   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
 
 # Builder
-FROM alpine:3.12 as builder
 
-RUN apk add ca-certificates alpine-sdk autoconf automake git libtool gmp-dev \
-    sqlite-dev python2 python3 py3-pip py3-mako net-tools zlib-dev libsodium gettext jq
-RUN pip3 install mrkd mistune==0.8.4
+# This dockerfile is meant to compile a core-lightning x64 image
+# It is using multi stage build:
+# * downloader: Download litecoin/bitcoin and qemu binaries needed for core-lightning
+# * builder: Compile core-lightning dependencies, then core-lightning itself with static linking
+# * final: Copy the binaries required at runtime
+# The resulting image uploaded to dockerhub will only contain what is needed for runtime.
+# From the root of the repository, run "docker build -t yourimage:yourtag ."
+FROM debian:bullseye-slim as downloader
 
-ADD ./.gitmodules /root/.gitmodules
-ADD ./.git /root/.git
-ADD ./lightning /root/lightning
-WORKDIR /root/lightning
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -qq --no-install-recommends ca-certificates dirmngr wget
 
-RUN rm -rf cli/test/*.c
-RUN ./configure
-RUN make -j$(($(nproc) - 1))
-RUN make install
+WORKDIR /opt
+
+RUN wget -qO /opt/tini "https://github.com/krallin/tini/releases/download/v0.18.0/tini" \
+    && echo "12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855 /opt/tini" | sha256sum -c - \
+    && chmod +x /opt/tini
+
+ARG BITCOIN_VERSION=22.0
+ENV BITCOIN_TARBALL bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$BITCOIN_TARBALL
+ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/SHA256SUMS
+
+RUN mkdir /opt/bitcoin && cd /opt/bitcoin \
+    && wget -qO $BITCOIN_TARBALL "$BITCOIN_URL" \
+    && wget -qO bitcoin "$BITCOIN_ASC_URL" \
+    && grep $BITCOIN_TARBALL bitcoin | tee SHA256SUMS \
+    && sha256sum -c SHA256SUMS \
+    && BD=bitcoin-$BITCOIN_VERSION/bin \
+    && tar -xzvf $BITCOIN_TARBALL $BD/bitcoin-cli --strip-components=1 \
+    && rm $BITCOIN_TARBALL
+
+ENV LITECOIN_VERSION 0.16.3
+ENV LITECOIN_PGP_KEY FE3348877809386C
+ENV LITECOIN_URL https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz
+ENV LITECOIN_ASC_URL https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux-signatures.asc
+ENV LITECOIN_SHA256 686d99d1746528648c2c54a1363d046436fd172beadaceea80bdc93043805994
+
+# install litecoin binaries
+RUN mkdir /opt/litecoin && cd /opt/litecoin \
+    && wget -qO litecoin.tar.gz "$LITECOIN_URL" \
+    && echo "$LITECOIN_SHA256  litecoin.tar.gz" | sha256sum -c - \
+    && BD=litecoin-$LITECOIN_VERSION/bin \
+    && tar -xzvf litecoin.tar.gz $BD/litecoin-cli --strip-components=1 --exclude=*-qt \
+    && rm litecoin.tar.gz
+
+FROM debian:bullseye-slim as builder
+
+ENV LIGHTNINGD_VERSION=master
+RUN apt-get update -qq && \
+    apt-get install -qq -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        curl \
+        dirmngr \
+        gettext \
+        git \
+        gnupg \
+        libpq-dev \
+        libtool \
+        libffi-dev \
+        python3 \
+        python3-dev \
+        python3-mako \
+        python3-pip \
+        python3-venv \
+        python3-setuptools \
+        wget
+
+RUN wget -q https://zlib.net/zlib-1.2.12.tar.gz \
+&& tar xvf zlib-1.2.12.tar.gz \
+&& cd zlib-1.2.12 \
+&& ./configure \
+&& make \
+&& make install && cd .. && rm zlib-1.2.12.tar.gz && rm -rf zlib-1.2.12
+
+RUN apt-get install -y --no-install-recommends unzip tclsh \
+&& wget -q https://www.sqlite.org/2019/sqlite-src-3290000.zip \
+&& unzip sqlite-src-3290000.zip \
+&& cd sqlite-src-3290000 \
+&& ./configure --enable-static --disable-readline --disable-threadsafe --disable-load-extension \
+&& make \
+&& make install && cd .. && rm sqlite-src-3290000.zip && rm -rf sqlite-src-3290000
+
+RUN wget -q https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz \
+&& tar xvf gmp-6.1.2.tar.xz \
+&& cd gmp-6.1.2 \
+&& ./configure --disable-assembly \
+&& make \
+&& make install && cd .. && rm gmp-6.1.2.tar.xz && rm -rf gmp-6.1.2
+
+ENV RUST_PROFILE=release
+ENV PATH=$PATH:/root/.cargo/bin/
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN rustup toolchain install stable --component rustfmt --allow-downgrade
+
+WORKDIR /opt/lightningd
+COPY lightning/. /tmp/lightning
+RUN git clone --recursive /tmp/lightning . && \
+    git checkout $(git --work-tree=/tmp/lightning --git-dir=/tmp/lightning/.git rev-parse HEAD)
+ARG DEVELOPER=0
+ENV PYTHON_VERSION=3
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 - \
+    && pip3 install -U pip \
+    && pip3 install -U wheel \
+    && /root/.local/bin/poetry config virtualenvs.create false \
+    && /root/.local/bin/poetry install
+
+RUN ./configure --prefix=/tmp/lightning_install --enable-static && make -j3 DEVELOPER=${DEVELOPER} && make install
+
+FROM debian:bullseye-slim as final
+
+COPY --from=downloader /opt/tini /usr/bin/tini
+RUN apt-get update && apt-get install -y --no-install-recommends socat inotify-tools python3 python3-pip libpq5\
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LIGHTNINGD_DATA=/root/.lightning
+ENV LIGHTNINGD_RPC_PORT=9835
+ENV LIGHTNINGD_PORT=9735
+ENV LIGHTNINGD_NETWORK=bitcoin
+
+RUN mkdir $LIGHTNINGD_DATA && \
+    touch $LIGHTNINGD_DATA/config
+VOLUME [ "/root/.lightning" ]
+COPY --from=builder /tmp/lightning_install/ /usr/local/
+COPY --from=downloader /opt/bitcoin/bin /usr/bin
+COPY --from=downloader /opt/litecoin/bin /usr/bin
+# COPY lightning/tools/docker-entrypoint.sh entrypoint.sh
+
+# EXPOSE 9735 9835
+# ENTRYPOINT  [ "/usr/bin/tini", "-g", "--", "./entrypoint.sh" ]
+
+
+# FROM alpine:3.12 as builder
+
+# RUN apk add ca-certificates alpine-sdk autoconf automake git libtool gmp-dev \
+#     sqlite-dev python2 python3 py3-pip py3-mako net-tools zlib-dev libsodium gettext jq
+# RUN pip3 install mrkd mistune==0.8.4
+
+# ADD ./.gitmodules /root/.gitmodules
+# ADD ./.git /root/.git
+# ADD ./lightning /root/lightning
+# WORKDIR /root/lightning
+
+# RUN rm -rf cli/test/*.c
+# RUN ./configure
+# RUN make -j$(($(nproc) - 1))
+# RUN make install
 
 
 
-# Runner
-FROM arm64v8/node:12-alpine3.12 as runner
+# # Runner
+# FROM arm64v8/node:12-alpine3.12 as runner
 
-RUN apk update
-RUN apk add bash tini
-RUN apk add sqlite-dev build-base linux-headers ca-certificates gcc gmp libffi-dev libgcc libevent libstdc++ boost-filesystem=1.72.0-r6 python3 python3-dev py3-pip nodejs
-RUN apk add --update openssl && \
-    rm -rf /var/cache/apk/*
+# RUN apk update
+# RUN apk add bash tini
+# RUN apk add sqlite-dev build-base linux-headers ca-certificates gcc gmp libffi-dev libgcc libevent libstdc++ boost-filesystem=1.72.0-r6 python3 python3-dev py3-pip nodejs
+# RUN apk add --update openssl && \
+#     rm -rf /var/cache/apk/*
 
-ARG BITCOIN_VERSION
-RUN test -n "$BITCOIN_VERSION"
+# ARG BITCOIN_VERSION
+# RUN test -n "$BITCOIN_VERSION"
 
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_arm.tar.gz -O - |\
-    tar xz && mv yq_linux_arm /usr/bin/yq
+# RUN wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_arm.tar.gz -O - |\
+#     tar xz && mv yq_linux_arm /usr/bin/yq
 
-COPY --from=builder /usr/local /usr/local
-COPY --from=bitcoin-core /bitcoin-${BITCOIN_VERSION}/src/bitcoin-cli /usr/local/bin
+# COPY --from=builder /usr/local /usr/local
+# COPY --from=bitcoin-core /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt /usr/local/bin
 
 # PLUGINS
 RUN pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,11 +136,7 @@ COPY --from=downloader /opt/bitcoin/bin /usr/bin
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_arm.tar.gz -O - |\
     tar xz && mv yq_linux_arm /usr/bin/yq
 
-# COPY --from=builder /usr/local /usr/local
-# COPY --from=bitcoin-core /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt /usr/local/bin
-
 # PLUGINS
-# RUN mkdir -p /usr/local/libexec/c-lightning/plugins
 WORKDIR /usr/local/libexec/c-lightning/plugins
 RUN pip install -U pip
 RUN pip install wheel

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ASSETS := $(shell yq e ".assets.[].src" manifest.yaml)
 ASSET_PATHS := $(addprefix assets/,$(ASSETS))
-BITCOIN_VERSION := "0.21.1"
+BITCOIN_VERSION := "22.0"
 C_LIGHTNING_GIT_REF := $(shell cat .git/modules/lightning/HEAD)
 C_LIGHTNING_GIT_FILE := $(addprefix .git/modules/lightning/,$(if $(filter ref:%,$(C_LIGHTNING_GIT_REF)),$(lastword $(C_LIGHTNING_GIT_REF)),HEAD))
 C_LIGHTNING_REST_SRC := $(shell find ./c-lightning-REST)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ c-lightning.s9pk: manifest.yaml assets/compat/* image.tar instructions.md $(ASSE
 image.tar: Dockerfile docker_entrypoint.sh check-rpc.sh check-synced.sh configurator/target/aarch64-unknown-linux-musl/release/configurator c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin $(C_LIGHTNING_GIT_FILE) $(PLUGINS_SRC) $(C_LIGHTNING_REST_SRC) manifest.yaml
 	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/c-lightning/main:$(VERSION) --build-arg BITCOIN_VERSION=$(BITCOIN_VERSION) --platform=linux/arm64/v8 -o type=docker,dest=image.tar .
 
-
 c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin: $(HTTP_PLUGIN_SRC)
 	docker run --rm -it -v ~/.cargo/registry:/root/.cargo/registry -v "$(shell pwd)"/c-lightning-http-plugin:/home/rust/src start9/rust-musl-cross:aarch64-musl cargo +beta build --release
 	docker run --rm -it -v ~/.cargo/registry:/root/.cargo/registry -v "$(shell pwd)"/c-lightning-http-plugin:/home/rust/src start9/rust-musl-cross:aarch64-musl musl-strip target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,15 @@ c-lightning.s9pk: manifest.yaml assets/compat/* image.tar instructions.md $(ASSE
 	embassy-sdk pack
 
 image.tar: Dockerfile docker_entrypoint.sh check-rpc.sh check-synced.sh configurator/target/aarch64-unknown-linux-musl/release/configurator c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin $(C_LIGHTNING_GIT_FILE) $(PLUGINS_SRC) $(C_LIGHTNING_REST_SRC) manifest.yaml
+# dumb hack to give the c-lightning build a .git folder because it insists on breaking on a submodule .git file
+	rm -rf tmp/
+	mv lightning/.git lightning/.git.save || true
+	git clone --no-checkout https://github.com/ElementsProject/lightning tmp/
+	cp -r tmp/.git lightning/
 	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/c-lightning/main:$(VERSION) --build-arg BITCOIN_VERSION=$(BITCOIN_VERSION) --platform=linux/arm64/v8 -o type=docker,dest=image.tar .
+	rm -rf lightning/.git
+	mv lightning/.git.save lightning/.git || true
+	rm -rf tmp/
 
 c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin: $(HTTP_PLUGIN_SRC)
 	docker run --rm -it -v ~/.cargo/registry:/root/.cargo/registry -v "$(shell pwd)"/c-lightning-http-plugin:/home/rust/src start9/rust-musl-cross:aarch64-musl cargo +beta build --release

--- a/assets/compat/config_spec.yaml
+++ b/assets/compat/config_spec.yaml
@@ -283,3 +283,12 @@ advanced:
 
             Source: https://github.com/Ride-The-Lightning/c-lightning-REST
           default: true
+        clboss:
+          type: boolean
+          name: Enable CLBOSS Plugin
+          description: |
+            CLBOSS is an automated manager for Core Lightning forwarding nodes.
+            Can be called via command line or the Spark console.        
+
+            Source: https://github.com/ZmnSCPxj/clboss
+          default: false

--- a/configurator/src/config.template
+++ b/configurator/src/config.template
@@ -31,3 +31,4 @@ cltv-delta={cltv_delta}
 {enable_rebalance_plugin}
 {enable_summary_plugin}
 {enable_rest_plugin}
+{enable_clboss_plugin}

--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -92,6 +92,7 @@ struct PluginConfig {
     rebalance: bool,
     summary: bool,
     rest: bool,
+    clboss: bool,
 }
 
 #[derive(serde::Serialize)]
@@ -305,6 +306,11 @@ fn main() -> Result<(), anyhow::Error> {
         } else {
             ""
         },
+        enable_clboss_plugin = if config.advanced.plugins.clboss {
+            "plugin=/usr/local/libexec/c-lightning/plugins/clboss"
+        } else {
+            ""
+        },
     )?;
     drop(outfile);
     #[derive(serde::Deserialize)]
@@ -312,7 +318,7 @@ fn main() -> Result<(), anyhow::Error> {
         id: String,
         alias: String,
     }
-    
+
     let rpc_path = Path::new("/root/.lightning/bitcoin/lightning-rpc");
     if rpc_path.exists() {
         std::fs::remove_file(rpc_path)?;

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -40,8 +40,8 @@ do
     sleep 1
 done
 cp /usr/local/libexec/c-lightning/plugins/c-lightning-REST/certs/access.macaroon /root/.lightning/public/access.macaroon
-cat /root/.lightning/public/access.macaroon | base64  > /root/.lightning/start9/access.macaroon.base64
-cat /root/.lightning/public/access.macaroon | base64 | xxd  > /root/.lightning/start9/access.macaroon.hex
+cat /root/.lightning/public/access.macaroon | basenc --base64url -w0  > /root/.lightning/start9/access.macaroon.base64
+cat /root/.lightning/public/access.macaroon | basenc --base16 -w0  > /root/.lightning/start9/access.macaroon.hex
 
 lightning-cli getinfo > /root/.lightning/start9/lightningGetInfo
 

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -47,5 +47,4 @@ lightning-cli getinfo > /root/.lightning/start9/lightningGetInfo
 
 echo "All configuration Done"
 
-
-wait -n
+wait

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -179,7 +179,7 @@ backup:
       main: /root/.lightning
 migrations:
   from:
-    "<0.11.1":
+    "*":
       type: docker
       image: main
       system: false
@@ -188,7 +188,7 @@ migrations:
       io-format: json
       inject: false
   to:
-    "<0.11.1":
+    "*":
       type: docker
       image: main
       system: false

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -10,6 +10,6 @@ export type {
   PackagePropertyObject,
   Properties,
   SetResult,
-} from "https://start9.com/procedure/types.0.3.1.d.ts";
+} from "https://raw.githubusercontent.com/Start9Labs/embassy-os/3d91bca8691fdcfc63007d27b782d07ad7b2b239/libs/artifacts/types.d.ts";
 
 export { matches };

--- a/scripts/models/setConfig.ts
+++ b/scripts/models/setConfig.ts
@@ -17,7 +17,7 @@ export const setConfigMatcher = shape(
         type: literal("internal-proxy"),
         user: string.optional(),
         password: string.optional(),
-      })    
+      })
     ),
     rpc: shape({
       enabled: boolean,
@@ -44,6 +44,7 @@ export const setConfigMatcher = shape(
         rebalance: boolean,
         summary: boolean,
         rest: boolean,
+        clboss: boolean,
       }),
     }),
   },

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -284,6 +284,12 @@ export async function getConfig(effects: Effects): Promise<ConfigRes> {
                 "name": "Enable C-Lightning-REST Plugin",
                 "description": "This plugin exposes an LND-like REST API. It is required for Ride The Lighting to connect to Core Lightning.\n\nSource: https://github.com/Ride-The-Lightning/c-lightning-REST\n",
                 "default": true
+              },
+              "clboss": {
+                "type": "boolean",
+                "name": "Enable C-Lightning-REST Plugin",
+                "description": "CLBOSS is an automated manager for Core Lightning forwarding nodes.\n\nSource: https://github.com/ZmnSCPxj/clboss\n",
+                "default": true
               }
             }
           }

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -256,42 +256,42 @@ export const getConfig: ExpectedExports.getConfig = async (effects) => {
                   "default": false
                 }
               }
-            }
-          },
-          "plugins": {
-            "type": "object",
-            "name": "Plugins",
-            "description": "Plugins are subprocesses that provide extra functionality and run alongside the lightningd process inside \nthe main Core Lightning container in order to communicate directly with it.\nTheir source is maintained separately from that of Core Lightning itself.\n",
-            "spec": {
-              "http": {
-                "type": "boolean",
-                "name": "Enable C-Lightning-HTTP-Plugin",
-                "description": "This plugin is a direct proxy for the unix domain socket from the HTTP interface. \nIt is required for Spark Wallet to connect to Core Lightning.\n\nSource: https://github.com/Start9Labs/c-lightning-http-plugin\n",
-                "default": true
-              },
-              "rebalance": {
-                "type": "boolean",
-                "name": "Enable Rebalance Plugin",
-                "description": "Enables the `rebalance` rpc command, which moves liquidity between your channels using circular payments.\nSee `help rebalance` on the CLI or in the Spark console for usage instructions.\n\nSource: https://github.com/lightningd/plugins/tree/master/rebalance\n",
-                "default": false
-              },
-              "summary": {
-                "type": "boolean",
-                "name": "Enable Summary Plugin",
-                "description": "Enables the `summary` rpc command, which outputs a text summary of your node, including fiat amounts.\nCan be called via command line or the Spark console.        \n\nSource: https://github.com/lightningd/plugins/tree/master/summary\n",
-                "default": false
-              },
-              "rest": {
-                "type": "boolean",
-                "name": "Enable C-Lightning-REST Plugin",
-                "description": "This plugin exposes an LND-like REST API. It is required for Ride The Lighting to connect to Core Lightning.\n\nSource: https://github.com/Ride-The-Lightning/c-lightning-REST\n",
-                "default": true
-              },
-              "clboss": {
-                "type": "boolean",
-                "name": "Enable C-Lightning-REST Plugin",
-                "description": "CLBOSS is an automated manager for Core Lightning forwarding nodes.\n\nSource: https://github.com/ZmnSCPxj/clboss\n",
-                "default": true
+            },
+            "plugins": {
+              "type": "object",
+              "name": "Plugins",
+              "description": "Plugins are subprocesses that provide extra functionality and run alongside the lightningd process inside \nthe main Core Lightning container in order to communicate directly with it.\nTheir source is maintained separately from that of Core Lightning itself.\n",
+              "spec": {
+                "http": {
+                  "type": "boolean",
+                  "name": "Enable C-Lightning-HTTP-Plugin",
+                  "description": "This plugin is a direct proxy for the unix domain socket from the HTTP interface. \nIt is required for Spark Wallet to connect to Core Lightning.\n\nSource: https://github.com/Start9Labs/c-lightning-http-plugin\n",
+                  "default": true
+                },
+                "rebalance": {
+                  "type": "boolean",
+                  "name": "Enable Rebalance Plugin",
+                  "description": "Enables the `rebalance` rpc command, which moves liquidity between your channels using circular payments.\nSee `help rebalance` on the CLI or in the Spark console for usage instructions.\n\nSource: https://github.com/lightningd/plugins/tree/master/rebalance\n",
+                  "default": false
+                },
+                "summary": {
+                  "type": "boolean",
+                  "name": "Enable Summary Plugin",
+                  "description": "Enables the `summary` rpc command, which outputs a text summary of your node, including fiat amounts.\nCan be called via command line or the Spark console.        \n\nSource: https://github.com/lightningd/plugins/tree/master/summary\n",
+                  "default": false
+                },
+                "rest": {
+                  "type": "boolean",
+                  "name": "Enable C-Lightning-REST Plugin",
+                  "description": "This plugin exposes an LND-like REST API. It is required for Ride The Lighting to connect to Core Lightning.\n\nSource: https://github.com/Ride-The-Lightning/c-lightning-REST\n",
+                  "default": true
+                },
+                "clboss": {
+                  "type": "boolean",
+                  "name": "Enable CLBOSS Plugin",
+                  "description": "CLBOSS is an automated manager for Core Lightning forwarding nodes.\n\nSource: https://github.com/ZmnSCPxj/clboss\n",
+                  "default": true
+                }
               }
             }
           }

--- a/scripts/services/setConfig.ts
+++ b/scripts/services/setConfig.ts
@@ -149,6 +149,9 @@ function configMaker(alias: Alias, config: SetConfig) {
   const enableRestPlugin = config.advanced.plugins.rest
     ? "plugin=/usr/local/libexec/c-lightning/plugins/c-lightning-REST/plugin.js\nrest-port=3001\nrest-protocol=https\n"
     : "";
+  const enableClbossPlugin = config.advanced.plugins.clboss
+    ? "plugin=/usr/local/libexec/c-lightning/plugins/clboss"
+    : "";
 
   return `
 network=bitcoin
@@ -183,7 +186,8 @@ ${enableExperimentalShutdownWrongFunding}
 ${enableHttpPlugin}
 ${enableRebalancePlugin}
 ${enableSummaryPlugin}
-${enableRestPlugin}`;
+${enableRestPlugin}
+${enableClbossPlugin}`;
 }
 
 export async function setConfig(effects: Effects, input: Config): Promise<KnownError | SetResult> {


### PR DESCRIPTION
This PR fixes everything

- Python plugins (broken in last release):
  - rebalance
  - summary

- Builds in a sensible way due to using debian instead of alpine
- Adds CLBOSS plugin
- Now builds on Mac
- Produces a much smaller image than before, not counting the CLBOSS binary

TODO: 
- [ ] ~~the binary for CLBOSS is currently 350 MB, need to shrink~~ binary is huge, hopefully can be solved upstream (https://github.com/ZmnSCPxj/clboss/issues/138)
- [x] Fix build, currently we manually need to `git clone --no-checkout` in order to get the `.git` dir from the submodule repo, since the build is not expecting a submodule