### PR TITLE
Update v0.11.2-modified and add CLBOSS config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 c-lightning.s9pk
 image.tar
 scripts/embassy.js
-tmp/
+.vscode/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ VOLUME [ "/root/.lightning" ]
 COPY --from=builder /tmp/lightning_install/ /usr/local/
 COPY --from=downloader /opt/bitcoin/bin /usr/bin
 
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_arm.tar.gz -O - |\
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_arm.tar.gz -O - |\
     tar xz && mv yq_linux_arm /usr/bin/yq
 
 # PLUGINS

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,37 @@ RUN mkdir /opt/bitcoin && cd /opt/bitcoin \
     && tar -xzvf $BITCOIN_TARBALL $BD/bitcoin-cli --strip-components=1 \
     && rm $BITCOIN_TARBALL
 
+# clboss builder
+FROM debian:bullseye-slim as clboss
+
+RUN apt-get update -qq && \
+    apt-get install -qq -y --no-install-recommends \
+        # autoconf \
+        autoconf-archive \
+        automake \
+        build-essential \
+        git \
+        libcurl4-gnutls-dev \
+        libev-dev \
+        libsqlite3-dev \
+        libtool \
+        pkg-config
+
+COPY clboss/. /tmp/clboss
+WORKDIR /tmp/clboss
+RUN autoreconf -i
+RUN ./configure
+RUN make
+RUN make install
+RUN strip /usr/local/bin/clboss
+
+# lightningd builder
 FROM debian:bullseye-slim as builder
 
-ENV LIGHTNINGD_VERSION=master
+ENV LIGHTNINGD_VERSION=v0.11.2
 RUN apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
         autoconf \
-        autoconf-archive \
         automake \
         build-essential \
         ca-certificates \
@@ -39,13 +63,9 @@ RUN apt-get update -qq && \
         gettext \
         git \
         gnupg \
-        libcurl4-gnutls-dev \
-        libev-dev \
         libpq-dev \
-        libsqlite3-dev \
         libtool \
         libffi-dev \
-        pkg-config \
         python3 \
         python3-dev \
         python3-mako \
@@ -53,14 +73,6 @@ RUN apt-get update -qq && \
         python3-venv \
         python3-setuptools \
         wget
-
-# CLBOSS
-COPY clboss/. /tmp/clboss
-WORKDIR /tmp/clboss
-RUN autoreconf -i
-RUN ./configure
-RUN make
-RUN make install
 
 # CLN
 RUN wget -q https://zlib.net/zlib-1.2.12.tar.gz \
@@ -91,9 +103,12 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN rustup toolchain install stable --component rustfmt --allow-downgrade
 
 WORKDIR /opt/lightningd
-COPY lightning/. /tmp/lightning
-RUN git clone --recursive /tmp/lightning . && \
-    git checkout $(git --work-tree=/tmp/lightning --git-dir=/tmp/lightning/.git rev-parse HEAD)
+COPY ./.git /tmp/lightning-wrapper/.git
+COPY lightning/. /tmp/lightning-wrapper/lightning
+# COPY lightning/. /opt/lightningd
+RUN git clone --recursive /tmp/lightning-wrapper/lightning . && \
+    git checkout $(git --work-tree=/tmp/lightning-wrapper/lightning --git-dir=/tmp/lightning-wrapper/lightning/.git rev-parse HEAD)
+    # git checkout $(git --git-dir=/tmp/lightning-wrapper/.git rev-parse HEAD)
 ARG DEVELOPER=0
 ENV PYTHON_VERSION=3
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 - \
@@ -163,7 +178,7 @@ RUN npm install --only=production
 ADD ./c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin /usr/local/libexec/c-lightning/plugins/c-lightning-http-plugin
 
 # CLBOSS
-COPY --from=builder /usr/local/bin/clboss /usr/local/libexec/c-lightning/plugins/clboss
+COPY --from=clboss /usr/local/bin/clboss /usr/local/libexec/c-lightning/plugins/clboss
 
 # other scripts
 ADD ./docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ C_LIGHTNING_REST_SRC := $(shell find ./c-lightning-REST)
 PLUGINS_SRC := $(shell find ./plugins)
 HTTP_PLUGIN_SRC := $(shell find ./c-lightning-http-plugin/src) c-lightning-http-plugin/Cargo.toml c-lightning-http-plugin/Cargo.lock
 VERSION := $(shell yq e ".version" manifest.yaml)
+TS_FILES := $(shell find ./**/*.ts)
 
 .DELETE_ON_ERROR:
 
@@ -26,5 +27,5 @@ c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-ht
 	docker run --rm -it -v ~/.cargo/registry:/root/.cargo/registry -v "$(shell pwd)"/c-lightning-http-plugin:/home/rust/src start9/rust-musl-cross:aarch64-musl cargo +beta build --release
 	docker run --rm -it -v ~/.cargo/registry:/root/.cargo/registry -v "$(shell pwd)"/c-lightning-http-plugin:/home/rust/src start9/rust-musl-cross:aarch64-musl musl-strip target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin
 
-scripts/embassy.js: scripts/**/*.ts
+scripts/embassy.js: $(TS_FILES)
 	deno bundle scripts/embassy.ts scripts/embassy.js

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,7 @@ c-lightning.s9pk: manifest.yaml image.tar instructions.md $(ASSET_PATHS)  script
 	embassy-sdk pack
 
 image.tar: Dockerfile docker_entrypoint.sh check-rpc.sh check-synced.sh c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin $(C_LIGHTNING_GIT_FILE) $(PLUGINS_SRC) $(C_LIGHTNING_REST_SRC) manifest.yaml
-# dumb hack to give the c-lightning build a .git folder because it insists on breaking on a submodule .git file
-	rm -rf tmp/
-	mv lightning/.git lightning/.git.save || true
-	git clone --no-checkout https://github.com/ElementsProject/lightning tmp/
-	cp -r tmp/.git lightning/
 	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/c-lightning/main:$(VERSION) --build-arg BITCOIN_VERSION=$(BITCOIN_VERSION) --platform=linux/arm64/v8 -o type=docker,dest=image.tar .
-	rm -rf lightning/.git
-	mv lightning/.git.save lightning/.git || true
-	rm -rf tmp/
 
 c-lightning-http-plugin/target/aarch64-unknown-linux-musl/release/c-lightning-http-plugin: $(HTTP_PLUGIN_SRC)
 	docker run --rm -it -v ~/.cargo/registry:/root/.cargo/registry -v "$(shell pwd)"/c-lightning-http-plugin:/home/rust/src start9/rust-musl-cross:aarch64-musl cargo +beta build --release

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -11,6 +11,41 @@ export EMBASSY_IP=$(ip -4 route list match 0/0 | awk '{print $3}')
 export PEER_TOR_ADDRESS=$(yq e '.peer-tor-address' /root/.lightning/start9/config.yaml)
 export RPC_TOR_ADDRESS=$(yq e '.rpc-tor-address' /root/.lightning/start9/config.yaml)
 
+if yq -e '.advanced.plugins.clboss.min-onchain' /root/.lightning/start9/config.yaml > /dev/null 2>&1; then
+  MIN_ONCHAIN_VALUE=$(yq e '.advanced.plugins.clboss.min-onchain' /root/.lightning/start9/config.yaml)
+  MIN_ONCHAIN=" --clboss-min-onchain=$MIN_ONCHAIN_VALUE"
+else
+  MIN_ONCHAIN=""
+fi
+
+if yq -e '.advanced.plugins.clboss.auto-close' /root/.lightning/start9/config.yaml > /dev/null 2>&1; then
+  AUTO_CLOSE_VALUE=$(yq e '.advanced.plugins.clboss.auto-close' /root/.lightning/start9/config.yaml)
+  AUTO_CLOSE=" --clboss-auto-close=$AUTO_CLOSE_VALUE"
+else
+  AUTO_CLOSE=""
+fi
+
+ZEROBASEFEE_VALUE=$(yq e '.advanced.plugins.clboss.zerobasefee' /root/.lightning/start9/config.yaml)
+if [ $ZEROBASEFEE_VALUE = "default" ]; then
+    ZEROBASEFEE=""
+else
+    ZEROBASEFEE=" --clboss-zerobasefee=$ZEROBASEFEE_VALUE"
+fi
+
+if yq -e '.advanced.plugins.clboss.min-channel' /root/.lightning/start9/config.yaml > /dev/null 2>&1; then
+  MIN_CHANNEL_VALUE=$(yq e '.advanced.plugins.clboss.min-channel' /root/.lightning/start9/config.yaml)
+  MIN_CHANNEL=" --clboss-min-channel=$MIN_CHANNEL_VALUE"
+else
+  MIN_CHANNEL=""
+fi
+
+if yq -e '.advanced.plugins.clboss.max-channel' /root/.lightning/start9/config.yaml > /dev/null 2>&1; then
+  MAX_CHANNEL_VALUE=$(yq e '.advanced.plugins.clboss.max-channel' /root/.lightning/start9/config.yaml)
+  MAX_CHANNEL=" --clboss-max-channel=$MAX_CHANNEL_VALUE"
+else
+  MAX_CHANNEL=""
+fi
+
 
 mkdir -p /root/.lightning/shared
 mkdir -p /root/.lightning/public
@@ -27,7 +62,7 @@ if [ -e /root/.lightning/bitcoin/lightning-rpc ]; then
 fi
 
 echo "Starting lightning"
-lightningd &
+lightningd$MIN_ONCHAIN$AUTO_CLOSE$ZEROBASEFEE$MIN_CHANNEL$MAX_CHANNEL &
 lightningd_child=$!
 
 while ! [ -e /root/.lightning/bitcoin/lightning-rpc ]; do

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,5 @@
 id: c-lightning
-version: 0.11.1.1
+version: 0.11.2
 title: Core Lightning
 license: BSD-MIT
 wrapper-repo: https://github.com/Start9Labs/c-lightning-wrapper

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -169,7 +169,7 @@ backup:
       main: /root/.lightning
 migrations:
   from:
-    "<0.11.1.1":
+    "<0.11.2":
       type: docker
       image: main
       system: false
@@ -177,12 +177,12 @@ migrations:
       args: ['{"configured": false}']
       io-format: json
       inject: false
-    "=0.11.1.1":
+    "=0.11.2":
       type: docker
       image: main
       system: false
       entrypoint: "/bin/echo"
-      args: ['{"configured": true}']
+      args: ['{"configured": false}']
       io-format: json
       inject: false
   to:
@@ -191,6 +191,6 @@ migrations:
       image: main
       system: false
       entrypoint: "/bin/echo"
-      args: ['{"configured": true}']
+      args: ['{"configured": false}']
       io-format: json
       inject: false

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -169,28 +169,10 @@ backup:
       main: /root/.lightning
 migrations:
   from:
-    "<0.11.2":
-      type: docker
-      image: main
-      system: false
-      entrypoint: "/bin/echo"
-      args: ['{"configured": false}']
-      io-format: json
-      inject: false
-    "=0.11.2":
-      type: docker
-      image: main
-      system: false
-      entrypoint: "/bin/echo"
-      args: ['{"configured": false}']
-      io-format: json
-      inject: false
+    "*":
+      type: script
+      args: ["from"]
   to:
     "*":
-      type: docker
-      image: main
-      system: false
-      entrypoint: "/bin/echo"
-      args: ['{"configured": false}']
-      io-format: json
-      inject: false
+      type: script
+      args: ["to"]

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,9 +7,8 @@ upstream-repo: https://github.com/ElementsProject/lightning
 support-site: https://github.com/ElementsProject/lightning/issues
 marketing-site: https://blockstream.com/lightning
 release-notes: |-
-  * New plugin: [CLBOSS Automated Node Manager](https://github.com/ZmnSCPxj/clboss) (see plugins section of config to enable)
-  * Fix `summary` and `rebalance` plugins
-  * Switch to using new eOS APIs for faster configuration and properties
+  * Update to [intermediate commit](https://github.com/ElementsProject/lightning/commit/b624c530515b3966ae08b740eac35bbec19da5de) on upstream in order to fix gossipd crashes. v0.11.2 didn't fix the crashes, but this slightly newer commit works great.
+  * Add more CLBOSS config options
 build: ["make"]
 description:
   short: "An implementation of the Lightning Network protocol by Blockstream."

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/embassyd_sdk@v0.3.1.0.3/mod.ts"; 
+export * from "https://deno.land/x/embassyd_sdk@v0.3.1.1.1/mod.ts"; 

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -1,2 +1,1 @@
-// export * from "https://deno.land/x/embassyd_sdk@v0.3.1.1.1/mod.ts";
-export * from "../../embassy-sdk-ts/mod.ts";
+export * from "https://deno.land/x/embassyd_sdk@v0.3.1.1.2/mod.ts";

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -1,1 +1,2 @@
-export * from "https://deno.land/x/embassyd_sdk@v0.3.1.1.1/mod.ts"; 
+// export * from "https://deno.land/x/embassyd_sdk@v0.3.1.1.1/mod.ts";
+export * from "../../embassy-sdk-ts/mod.ts";

--- a/scripts/embassy.ts
+++ b/scripts/embassy.ts
@@ -2,3 +2,4 @@ export { setConfig } from "./services/setConfig.ts";
 export { dependencies } from "./services/dependencies.ts";
 export { properties } from "./services/properties.ts";
 export { getConfig } from "./services/getConfig.ts";
+export { migration } from "./services/migrations.ts";

--- a/scripts/models/setConfig.ts
+++ b/scripts/models/setConfig.ts
@@ -1,6 +1,7 @@
 import { matches } from "../deps.ts";
 
-const { literal, literals, shape, number, string, some, boolean, object } = matches;
+const { literal, literals, shape, number, string, some, boolean, object } =
+  matches;
 export const setConfigMatcher = shape(
   {
     "peer-tor-address": string,
@@ -12,12 +13,12 @@ export const setConfigMatcher = shape(
         type: literal("internal"),
         user: string.optional(),
         password: string.optional(),
-      }, ['user', 'password']),
+      }, ["user", "password"]),
       shape({
         type: literal("internal-proxy"),
         user: string.optional(),
         password: string.optional(),
-      }, ['user', 'password'])
+      }, ["user", "password"]),
     ),
     rpc: shape({
       enabled: boolean,
@@ -47,13 +48,19 @@ export const setConfigMatcher = shape(
         clboss: shape({
           "min-onchain": number,
           "auto-close": boolean,
-          "zerobasefee": literals('default', 'required', 'allow', 'disallow'),
+          "zerobasefee": literals("default", "required", "allow", "disallow"),
           "min-channel": number,
           "max-channel": number,
-        }, ["min-onchain", "auto-close", "zerobasefee", "min-channel", "max-channel"]),
+        }, [
+          "min-onchain",
+          "auto-close",
+          "zerobasefee",
+          "min-channel",
+          "max-channel",
+        ]),
       }),
     }),
   },
-  ["alias", "peer-tor-address", 'rpc-tor-address']
+  ["alias", "peer-tor-address", "rpc-tor-address"],
 );
 export type SetConfig = typeof setConfigMatcher._TYPE;

--- a/scripts/models/setConfig.ts
+++ b/scripts/models/setConfig.ts
@@ -1,6 +1,6 @@
 import { matches } from "../deps.ts";
 
-const { literal, shape, number, string, some, boolean } = matches;
+const { literal, literals, shape, number, string, some, boolean, object } = matches;
 export const setConfigMatcher = shape(
   {
     "peer-tor-address": string,
@@ -44,7 +44,13 @@ export const setConfigMatcher = shape(
         rebalance: boolean,
         summary: boolean,
         rest: boolean,
-        clboss: boolean,
+        clboss: shape({
+          "min-onchain": number,
+          "auto-close": boolean,
+          "zerobasefee": literals('default', 'required', 'allow', 'disallow'),
+          "min-channel": number,
+          "max-channel": number,
+        }, ["min-onchain", "auto-close", "zerobasefee", "min-channel", "max-channel"]),
       }),
     }),
   },

--- a/scripts/services/dependencies.ts
+++ b/scripts/services/dependencies.ts
@@ -1,4 +1,4 @@
-import { types as T, matches } from "../deps.ts";
+import { matches, types as T } from "../deps.ts";
 
 const { shape, arrayOf, string, boolean } = matches;
 
@@ -11,8 +11,8 @@ const matchProxyConfig = shape({
         password: string,
         "fetch-blocks": boolean,
       },
-      ["fetch-blocks"]
-    )
+      ["fetch-blocks"],
+    ),
   ),
 });
 
@@ -29,7 +29,8 @@ function randomItemString(input: string) {
 }
 
 const serviceName = "c-lightning";
-const fullChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const fullChars =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 type Check = {
   currentError(config: T.Config): string | void;
   fix(config: T.Config): void;
@@ -48,7 +49,7 @@ const checks: Array<Check> = [
     },
     fix(config) {
       if (!matchProxyConfig.test(config)) {
-        return
+        return;
       }
       config.users.push({
         name: serviceName,
@@ -73,7 +74,10 @@ const checks: Array<Check> = [
         if (!matchProxyConfig.test(config)) {
           return "Config is not the correct shape";
         }
-        if (config.users.find((x) => x.name === serviceName)?.["allowed-calls"]?.some((x) => x === operator) ?? false) {
+        if (
+          config.users.find((x) => x.name === serviceName)?.["allowed-calls"]
+            ?.some((x) => x === operator) ?? false
+        ) {
           return;
         }
         return `RPC user "c-lightning" must have "${operator}" enabled`;
@@ -88,14 +92,17 @@ const checks: Array<Check> = [
         }
         found["allowed-calls"] = [...(found["allowed-calls"] ?? []), operator];
       },
-    })
+    }),
   ),
   {
     currentError(config) {
       if (!matchProxyConfig.test(config)) {
         return "Config is not the correct shape";
       }
-      if (config.users.find((x) => x.name === serviceName)?.["fetch-blocks"] ?? false) {
+      if (
+        config.users.find((x) => x.name === serviceName)?.["fetch-blocks"] ??
+          false
+      ) {
         return;
       }
       return `RPC user "c-lightning" must have "Fetch Blocks" enabled`;
@@ -153,7 +160,10 @@ export const dependencies: T.ExpectedExports.dependencies = {
       effects.info("check bitcoind");
       const config = matchBitcoindConfig.unsafeCast(configInput);
       if (config.advanced.pruning.mode !== "disabled") {
-        return { error: 'Pruning must be disabled to use Bitcoin Core directly. To use with a pruned node, set Bitcoin Core to "Internal (Bitcoin Proxy)" instead.' };
+        return {
+          error:
+            'Pruning must be disabled to use Bitcoin Core directly. To use with a pruned node, set Bitcoin Core to "Internal (Bitcoin Proxy)" instead.',
+        };
       }
       return { result: null };
     },

--- a/scripts/services/getAlias.ts
+++ b/scripts/services/getAlias.ts
@@ -2,7 +2,10 @@ import { types as T } from "../deps.ts";
 import { SetConfig } from "../models/setConfig.ts";
 
 export type Alias = string & { _type: "alias" };
-export async function getAlias(effects: T.Effects, config: SetConfig): Promise<Alias> {
+export async function getAlias(
+  effects: T.Effects,
+  config: SetConfig,
+): Promise<Alias> {
   if (config.alias) {
     return config.alias as Alias;
   }
@@ -12,7 +15,9 @@ export async function getAlias(effects: T.Effects, config: SetConfig): Promise<A
       path: "default_alias.txt",
     })) as Alias;
   } catch (_e) {
-    const alias = `start9-${(Math.random().toString(36) + "00000000000000011").slice(2, 9 + 2)}`;
+    const alias = `start9-${
+      (Math.random().toString(36) + "00000000000000011").slice(2, 9 + 2)
+    }`;
     await effects.writeFile({
       volumeId: "main",
       path: "default_alias.txt",

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -273,11 +273,76 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
             "default": true
           },
           "clboss": {
-            "type": "boolean",
-            "name": "Enable CLBOSS Plugin",
-            "description": "CLBOSS is an automated manager for Core Lightning forwarding nodes.\n\nSource: https://github.com/ZmnSCPxj/clboss\n",
-            "default": false
-          }
+            "type": "union",
+            "name": "CLBOSS settings",
+            "description":
+              "CLBOSS is an automated manager for Core Lightning forwarding nodes.\n\nSource: https://github.com/ZmnSCPxj/clboss\n",
+            "warning":
+              "CLBOSS automatically manages your CLN node. It is experimental software and will probably not be profitable to run. It will automatically open channels, buy incoming liquidity, rebalance channels, and set forwarding fees. If you don't want this behavior or don't understand what this means, please keep this option disabled. For more info, see: Source: https://github.com/ZmnSCPxj/clboss#operating .",
+            "tag": {
+              "id": "enabled",
+              "name": "CLBOSS Enabled",
+              "description":
+                '- Disabled: Disable CLBOSS\n- Enabled: Enable CLBOSS',
+              "variant-names": {
+                "disabled": "Disabled",
+                "enabled": "Enabled",
+              },
+            },
+            "default": "disabled",
+            "variants": {
+              "disabled": {},
+              "enabled": {
+                "min-onchain": {
+                  "type": "number",
+                  "nullable": true,
+                  "name": "Minimum On-Chain",
+                  "description": "Pass this option to lightningd in order to specify a target amount that CLBOSS will leave onchain. The amount specified must be an ordinary number, and must be in satoshis unit, without any trailing units or other strings. The default is \"30000\", or about 0.0003 BTC. The intent is that this minimal amount will be used in the future, by Core Lightning, to manage anchor-commitment channels, or post-Taproot Decker-Russell-Osuntokun channels. These channel types need some small amount of onchain funds to unilaterally close, so it is not recommended to set it to 0. The amount specified is a ballpark figure, and CLBOSS may leave slightly lower or slightly higher than this amount.",
+                  "range": "[0,10000000000)",
+                  "integral": true,
+                  "units": "satoshis",
+                },
+                "auto-close": {
+                  "type": "boolean",
+                  "name": "Auto Close",
+                  "description": "Set to true if you want CLBOSS to close channels it deems unprofitable.",
+                  "default": false,
+                  "warning": "This feature is EXPERIMENTAL!",
+                },
+                "zerobasefee": {
+                  "type": "enum",
+                  "name": "Zero Base Fee",
+                  "values": [
+                    "default",
+                    "required",
+                    "allow",
+                    "disallow",
+                  ],
+                  "value-names": {},
+                  "description": "Pass this option to lightningd to specify how this node will advertise its base_fee. require - the base_fee must be always 0. allow - if the heuristics of CLBOSS think it might be a good idea to set base_fee to 0, let it be 0, but otherwise set it to whatever value the heuristics want. disallow - the base_fee must always be non-0. If the heuristics think it might be good to set it to 0, set it to 1 instead. On 0.11C and earlier, CLBOSS had the disallow behavior. In this version, the default is the allow behavior. Some pathfinding algorithms under development may strongly prefer 0 or low base fees, so you might want to set CLBOSS to 0 base fee, or to allow a 0 base fee.",
+                  "default": "default",
+                },
+                "min-channel": {
+                  "type": "number",
+                  "nullable": true,
+                  "name": "Max Chain Size",
+                  "description": "Sets the minimum channel sizes that CLBOSS will make.",
+                  "range": "[0,10000000000)",
+                  "integral": true,
+                  "units": "satoshis",
+                },
+                "max-channel": {
+                  "type": "number",
+                  "nullable": true,
+                  "name": "Max Chain Size",
+                  "description": "Sets the maximum channel sizes that CLBOSS will make.",
+                  "range": "[0,10000000000)",
+                  "integral": true,
+                  "units": "satoshis",
+                },
+              },
+            },
+          },
         }
       }
     }

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -1,4 +1,4 @@
-import { matches, YAML, types as T, compat } from "../deps.ts";
+import { compat, matches, types as T, YAML } from "../deps.ts";
 
 const { any, string, dictionary } = matches;
 
@@ -12,7 +12,7 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     "subtype": "package",
     "package-id": "c-lightning",
     "target": "tor-address",
-    "interface": "peer"
+    "interface": "peer",
   },
   "rpc-tor-address": {
     "name": "RPC Tor Address",
@@ -21,7 +21,7 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     "subtype": "package",
     "package-id": "c-lightning",
     "target": "tor-address",
-    "interface": "rpc"
+    "interface": "rpc",
   },
   "alias": {
     "type": "string",
@@ -29,7 +29,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     "description": "Recognizable name for the Lightning Network",
     "nullable": true,
     "pattern": ".{1,32}",
-    "pattern-description": "Must be at least 1 character and no more than 32 characters"
+    "pattern-description":
+      "Must be at least 1 character and no more than 32 characters",
   },
   "color": {
     "type": "string",
@@ -37,11 +38,12 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     "description": "Color value for the Lightning Network",
     "nullable": false,
     "pattern": "[0-9a-fA-F]{6}",
-    "pattern-description": "Must be a valid 6 digit hexadecimal RGB value. The first two digits are red, middle two are green and final two are\nblue\n",
+    "pattern-description":
+      "Must be a valid 6 digit hexadecimal RGB value. The first two digits are red, middle two are green and final two are\nblue\n",
     "default": {
       "charset": "a-f,0-9",
-      "len": 6
-    }
+      "len": 6,
+    },
   },
   "bitcoind": {
     "type": "union",
@@ -52,9 +54,10 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
       "name": "Type",
       "variant-names": {
         "internal": "Bitcoin Core",
-        "internal-proxy": "Bitcoin Proxy"
+        "internal-proxy": "Bitcoin Proxy",
       },
-      "description": "Options<ul><li>Bitcoin Core: the Bitcoin Core node installed on your Embassy</li><li>Bitcoin Proxy: the Bitcoin Proxy service installed on your Embassy</li></ul>"
+      "description":
+        "Options<ul><li>Bitcoin Core: the Bitcoin Core node installed on your Embassy</li><li>Bitcoin Proxy: the Bitcoin Proxy service installed on your Embassy</li></ul>",
     },
     "default": "internal-proxy",
     "variants": {
@@ -67,7 +70,7 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
           "package-id": "bitcoind",
           "target": "config",
           "multi": false,
-          "selector": "$.rpc.username"
+          "selector": "$.rpc.username",
         },
         "password": {
           "type": "pointer",
@@ -77,32 +80,34 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
           "package-id": "bitcoind",
           "target": "config",
           "multi": false,
-          "selector": "$.rpc.password"
-        }
+          "selector": "$.rpc.password",
+        },
       },
       "internal-proxy": {
         "user": {
           "type": "pointer",
           "name": "RPC Username",
-          "description": "The username for the RPC user allocated to Core Lightning",
+          "description":
+            "The username for the RPC user allocated to Core Lightning",
           "subtype": "package",
           "package-id": "btc-rpc-proxy",
           "target": "config",
-          "selector": "$.users[?(@.name == \"c-lightning\")].name",
-          "multi": false
+          "selector": '$.users[?(@.name == "c-lightning")].name',
+          "multi": false,
         },
         "password": {
           "type": "pointer",
           "name": "RPC Password",
-          "description": "The password for the RPC user allocated to Core Lightning",
+          "description":
+            "The password for the RPC user allocated to Core Lightning",
           "subtype": "package",
           "package-id": "btc-rpc-proxy",
           "target": "config",
-          "selector": "$.users[?(@.name == \"c-lightning\")].password",
-          "multi": false
-        }
-      }
-    }
+          "selector": '$.users[?(@.name == "c-lightning")].password',
+          "multi": false,
+        },
+      },
+    },
   },
   "rpc": {
     "type": "object",
@@ -113,29 +118,31 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
         "type": "boolean",
         "name": "Enable",
         "description": "Whether to enable the RPC webserver",
-        "default": true
+        "default": true,
       },
       "user": {
         "type": "string",
         "name": "RPC Username",
-        "description": "The username for the RPC user on your Core Lightning node",
+        "description":
+          "The username for the RPC user on your Core Lightning node",
         "nullable": false,
         "default": "lightning",
-        "copyable": true
+        "copyable": true,
       },
       "password": {
         "type": "string",
         "name": "RPC Password",
-        "description": "The password for the RPC user on your Core Lightning node",
+        "description":
+          "The password for the RPC user on your Core Lightning node",
         "nullable": false,
         "default": {
           "charset": "a-z,A-Z,0-9",
-          "len": 22
+          "len": 22,
         },
         "copyable": true,
-        "masked": true
-      }
-    }
+        "masked": true,
+      },
+    },
   },
   "advanced": {
     "type": "object",
@@ -146,131 +153,148 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
         "type": "boolean",
         "name": "Only Use Tor",
         "description": "Use Tor for outgoing connections",
-        "default": false
+        "default": false,
       },
       "fee-base": {
         "type": "number",
         "name": "Routing Base Fee",
-        "description": "The base fee in millisatoshis you will charge for forwarding payments on your channels.\n",
+        "description":
+          "The base fee in millisatoshis you will charge for forwarding payments on your channels.\n",
         "nullable": false,
         "range": "[0,*)",
         "integral": true,
         "default": 1000,
-        "units": "millisatoshis"
+        "units": "millisatoshis",
       },
       "fee-rate": {
         "type": "number",
         "name": "Routing Fee Rate",
-        "description": "The fee rate used when forwarding payments on your channels. The total fee charged is\nthe Base Fee + (amount * Fee Rate / 1,000,000), where the amount is the forwarded amount.\nMeasured in sats per million.\n",
+        "description":
+          "The fee rate used when forwarding payments on your channels. The total fee charged is\nthe Base Fee + (amount * Fee Rate / 1,000,000), where the amount is the forwarded amount.\nMeasured in sats per million.\n",
         "nullable": false,
         "range": "[1,1000000)",
         "integral": true,
         "default": 1,
-        "units": "sats per million"
+        "units": "sats per million",
       },
       "min-capacity": {
         "type": "number",
         "name": "Minimum Channel Capacity",
-        "description": "This value defines the minimal effective channel capacity in satoshis to accept for channel opening requests.\nThis will reject any opening of a channel which can't pass an HTLC of at least this value. Usually this prevents\na peer opening a tiny channel, but it can also prevent a channel you open with a reasonable amount and the peer\nis requesting such a large reserve that the capacity of the channel falls below this.\n",
+        "description":
+          "This value defines the minimal effective channel capacity in satoshis to accept for channel opening requests.\nThis will reject any opening of a channel which can't pass an HTLC of at least this value. Usually this prevents\na peer opening a tiny channel, but it can also prevent a channel you open with a reasonable amount and the peer\nis requesting such a large reserve that the capacity of the channel falls below this.\n",
         "nullable": false,
         "range": "[1,16777215]",
         "integral": true,
         "default": 10000,
-        "units": "satoshis"
+        "units": "satoshis",
       },
       "ignore-fee-limits": {
         "type": "boolean",
         "name": "Ignore Fee Limits",
-        "description": "Allow nodes which establish channels to you to set any fee they want. This may result in a channel which cannot\nbe closed, should fees increase, but make channels far more reliable since Core Lightning will never close it due\nto unreasonable fees.\n",
-        "default": false
+        "description":
+          "Allow nodes which establish channels to you to set any fee they want. This may result in a channel which cannot\nbe closed, should fees increase, but make channels far more reliable since Core Lightning will never close it due\nto unreasonable fees.\n",
+        "default": false,
       },
       "funding-confirms": {
         "type": "number",
         "name": "Required Funding Confirmations",
-        "description": "Confirmations required for the funding transaction when the other side opens a channel before the channel is\nusable.\n",
+        "description":
+          "Confirmations required for the funding transaction when the other side opens a channel before the channel is\nusable.\n",
         "nullable": false,
         "range": "[1,6]",
         "integral": true,
         "default": 3,
-        "units": "blocks"
+        "units": "blocks",
       },
       "cltv-delta": {
         "type": "number",
         "name": "Time Lock Delta",
-        "description": "The number of blocks between the incoming payments and outgoing payments: this needs to be enough to make sure\nthat if it has to, Core Lightning can close the outgoing payment before the incoming, or redeem the incoming once\nthe outgoing is redeemed.\n",
+        "description":
+          "The number of blocks between the incoming payments and outgoing payments: this needs to be enough to make sure\nthat if it has to, Core Lightning can close the outgoing payment before the incoming, or redeem the incoming once\nthe outgoing is redeemed.\n",
         "nullable": false,
         "range": "[6,144]",
         "integral": true,
         "default": 40,
-        "units": "blocks"
+        "units": "blocks",
       },
       "wumbo-channels": {
         "type": "boolean",
         "name": "Enable Wumbo Channels",
-        "description": "Removes capacity limits for channel creation. Version 1.0 of the specification limited channel sizes to 16777215\nsatoshis. With this option (which your node will advertise to peers), your node will accept larger incoming\nchannels and if the peer supports it, will open larger channels.\n\nWarning: This is #Reckless and you should not enable it unless you deeply understand the risks associated with\nthe Lightning Network.\n",
-        "default": false
+        "description":
+          "Removes capacity limits for channel creation. Version 1.0 of the specification limited channel sizes to 16777215\nsatoshis. With this option (which your node will advertise to peers), your node will accept larger incoming\nchannels and if the peer supports it, will open larger channels.\n\nWarning: This is #Reckless and you should not enable it unless you deeply understand the risks associated with\nthe Lightning Network.\n",
+        "default": false,
       },
       "experimental": {
         "type": "object",
         "name": "Experimental Features",
-        "description": "Experimental features that have not been standardized across Lightning Network implementations",
-        "change-warning": "These are experimental features. Enable them at your own risk. It is possible that software bugs can lead to\nunknown problems. We recommend not using them with large amounts of money. Unless you understand how these\nfeatures work, you should not enable them.\n",
+        "description":
+          "Experimental features that have not been standardized across Lightning Network implementations",
+        "change-warning":
+          "These are experimental features. Enable them at your own risk. It is possible that software bugs can lead to\nunknown problems. We recommend not using them with large amounts of money. Unless you understand how these\nfeatures work, you should not enable them.\n",
         "spec": {
           "dual-fund": {
             "type": "boolean",
             "name": "Dual Funding",
-            "description": "Enables the option to dual fund channels with other compatible lightning implementations using the v2\nchannel opening protocol\n",
-            "default": false
+            "description":
+              "Enables the option to dual fund channels with other compatible lightning implementations using the v2\nchannel opening protocol\n",
+            "default": false,
           },
           "onion-messages": {
             "type": "boolean",
             "name": "Onion Messages",
-            "description": "Enable the sending, receiving, and relay of onion messages\n",
-            "default": false
+            "description":
+              "Enable the sending, receiving, and relay of onion messages\n",
+            "default": false,
           },
           "offers": {
             "type": "boolean",
             "name": "Offers",
-            "description": "Enable the sending and receiving of offers (this requires Onion Messages to be enabled as well)\n",
-            "default": false
+            "description":
+              "Enable the sending and receiving of offers (this requires Onion Messages to be enabled as well)\n",
+            "default": false,
           },
           "shutdown-wrong-funding": {
             "type": "boolean",
             "name": "Shutdown Wrong Funding",
             "description": "Allow channel shutdown with alternate txids\n",
-            "default": false
-          }
-        }
+            "default": false,
+          },
+        },
         // deno-lint-ignore no-explicit-any
       } as any,
       "plugins": {
         "type": "object",
         "name": "Plugins",
-        "description": "Plugins are subprocesses that provide extra functionality and run alongside the lightningd process inside \nthe main Core Lightning container in order to communicate directly with it.\nTheir source is maintained separately from that of Core Lightning itself.\n",
+        "description":
+          "Plugins are subprocesses that provide extra functionality and run alongside the lightningd process inside \nthe main Core Lightning container in order to communicate directly with it.\nTheir source is maintained separately from that of Core Lightning itself.\n",
         "spec": {
           "http": {
             "type": "boolean",
             "name": "Enable C-Lightning-HTTP-Plugin",
-            "description": "This plugin is a direct proxy for the unix domain socket from the HTTP interface. \nIt is required for Spark Wallet to connect to Core Lightning.\n\nSource: https://github.com/Start9Labs/c-lightning-http-plugin\n",
-            "default": true
+            "description":
+              "This plugin is a direct proxy for the unix domain socket from the HTTP interface. \nIt is required for Spark Wallet to connect to Core Lightning.\n\nSource: https://github.com/Start9Labs/c-lightning-http-plugin\n",
+            "default": true,
           },
           "rebalance": {
             "type": "boolean",
             "name": "Enable Rebalance Plugin",
-            "description": "Enables the `rebalance` rpc command, which moves liquidity between your channels using circular payments.\nSee `help rebalance` on the CLI or in the Spark console for usage instructions.\n\nSource: https://github.com/lightningd/plugins/tree/master/rebalance\n",
-            "default": false
+            "description":
+              "Enables the `rebalance` rpc command, which moves liquidity between your channels using circular payments.\nSee `help rebalance` on the CLI or in the Spark console for usage instructions.\n\nSource: https://github.com/lightningd/plugins/tree/master/rebalance\n",
+            "default": false,
           },
           "summary": {
             "type": "boolean",
             "name": "Enable Summary Plugin",
-            "description": "Enables the `summary` rpc command, which outputs a text summary of your node, including fiat amounts.\nCan be called via command line or the Spark console.        \n\nSource: https://github.com/lightningd/plugins/tree/master/summary\n",
-            "default": false
+            "description":
+              "Enables the `summary` rpc command, which outputs a text summary of your node, including fiat amounts.\nCan be called via command line or the Spark console.        \n\nSource: https://github.com/lightningd/plugins/tree/master/summary\n",
+            "default": false,
           },
           "rest": {
             "type": "boolean",
             "name": "Enable C-Lightning-REST Plugin",
-            "description": "This plugin exposes an LND-like REST API. It is required for Ride The Lighting to connect to Core Lightning.\n\nSource: https://github.com/Ride-The-Lightning/c-lightning-REST\n",
-            "default": true
+            "description":
+              "This plugin exposes an LND-like REST API. It is required for Ride The Lighting to connect to Core Lightning.\n\nSource: https://github.com/Ride-The-Lightning/c-lightning-REST\n",
+            "default": true,
           },
           "clboss": {
             "type": "union",
@@ -283,7 +307,7 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
               "id": "enabled",
               "name": "CLBOSS Enabled",
               "description":
-                '- Disabled: Disable CLBOSS\n- Enabled: Enable CLBOSS',
+                "- Disabled: Disable CLBOSS\n- Enabled: Enable CLBOSS",
               "variant-names": {
                 "disabled": "Disabled",
                 "enabled": "Enabled",
@@ -297,7 +321,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
                   "type": "number",
                   "nullable": true,
                   "name": "Minimum On-Chain",
-                  "description": "Pass this option to lightningd in order to specify a target amount that CLBOSS will leave onchain. The amount specified must be an ordinary number, and must be in satoshis unit, without any trailing units or other strings. The default is \"30000\", or about 0.0003 BTC. The intent is that this minimal amount will be used in the future, by Core Lightning, to manage anchor-commitment channels, or post-Taproot Decker-Russell-Osuntokun channels. These channel types need some small amount of onchain funds to unilaterally close, so it is not recommended to set it to 0. The amount specified is a ballpark figure, and CLBOSS may leave slightly lower or slightly higher than this amount.",
+                  "description":
+                    'Pass this option to lightningd in order to specify a target amount that CLBOSS will leave onchain. The amount specified must be an ordinary number, and must be in satoshis unit, without any trailing units or other strings. The default is "30000", or about 0.0003 BTC. The intent is that this minimal amount will be used in the future, by Core Lightning, to manage anchor-commitment channels, or post-Taproot Decker-Russell-Osuntokun channels. These channel types need some small amount of onchain funds to unilaterally close, so it is not recommended to set it to 0. The amount specified is a ballpark figure, and CLBOSS may leave slightly lower or slightly higher than this amount.',
                   "range": "[0,10000000000)",
                   "integral": true,
                   "units": "satoshis",
@@ -305,7 +330,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
                 "auto-close": {
                   "type": "boolean",
                   "name": "Auto Close",
-                  "description": "Set to true if you want CLBOSS to close channels it deems unprofitable.",
+                  "description":
+                    "Set to true if you want CLBOSS to close channels it deems unprofitable.",
                   "default": false,
                   "warning": "This feature is EXPERIMENTAL!",
                 },
@@ -319,14 +345,16 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
                     "disallow",
                   ],
                   "value-names": {},
-                  "description": "Pass this option to lightningd to specify how this node will advertise its base_fee. require - the base_fee must be always 0. allow - if the heuristics of CLBOSS think it might be a good idea to set base_fee to 0, let it be 0, but otherwise set it to whatever value the heuristics want. disallow - the base_fee must always be non-0. If the heuristics think it might be good to set it to 0, set it to 1 instead. On 0.11C and earlier, CLBOSS had the disallow behavior. In this version, the default is the allow behavior. Some pathfinding algorithms under development may strongly prefer 0 or low base fees, so you might want to set CLBOSS to 0 base fee, or to allow a 0 base fee.",
+                  "description":
+                    "Pass this option to lightningd to specify how this node will advertise its base_fee. require - the base_fee must be always 0. allow - if the heuristics of CLBOSS think it might be a good idea to set base_fee to 0, let it be 0, but otherwise set it to whatever value the heuristics want. disallow - the base_fee must always be non-0. If the heuristics think it might be good to set it to 0, set it to 1 instead. On 0.11C and earlier, CLBOSS had the disallow behavior. In this version, the default is the allow behavior. Some pathfinding algorithms under development may strongly prefer 0 or low base fees, so you might want to set CLBOSS to 0 base fee, or to allow a 0 base fee.",
                   "default": "default",
                 },
                 "min-channel": {
                   "type": "number",
                   "nullable": true,
                   "name": "Max Chain Size",
-                  "description": "Sets the minimum channel sizes that CLBOSS will make.",
+                  "description":
+                    "Sets the minimum channel sizes that CLBOSS will make.",
                   "range": "[0,10000000000)",
                   "integral": true,
                   "units": "satoshis",
@@ -335,7 +363,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
                   "type": "number",
                   "nullable": true,
                   "name": "Max Chain Size",
-                  "description": "Sets the maximum channel sizes that CLBOSS will make.",
+                  "description":
+                    "Sets the maximum channel sizes that CLBOSS will make.",
                   "range": "[0,10000000000)",
                   "integral": true,
                   "units": "satoshis",
@@ -343,8 +372,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
               },
             },
           },
-        }
-      }
-    }
-  }
-})
+        },
+      },
+    },
+  },
+});

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -7,7 +7,9 @@ export const migration: T.ExpectedExports.migration = compat.migrations
       // 0.11.1: no migration needed
       "0.11.1.1": {
         up: compat.migrations.updateConfig(
-          (config) => {
+          (config, effects) => {
+            effects.warn(`Up 0.11.1.1 ${JSON.stringify(config)}`);
+            effects.warn("UP 0.11.1.1");
             if (
               matches.shape({
                 advanced: matches.shape({ plugins: matches.any }),
@@ -21,54 +23,72 @@ export const migration: T.ExpectedExports.migration = compat.migrations
           { version: "0.11.1.1", type: "up" },
         ),
         down: compat.migrations.updateConfig(
-          (config) => {
+          (config, effects) => {
+            effects.warn(`Down 0.11.1.1 ${JSON.stringify(config)}`);
+            effects.warn("THIS IS A TEST OF THE EMERGENCY BROADCASTING SYSTEM");
             if (
-                matches.shape({
-                advanced: matches.shape({ plugins: matches.shape({ clboss: matches.any }) }),
-                }).test(config)
+              matches.shape({
+                advanced: matches.shape({
+                  plugins: matches.shape({ clboss: matches.any }),
+                }),
+              }).test(config)
             ) {
-                delete config.advanced.plugins.clboss;
+              delete config.advanced.plugins.clboss;
             }
             return config;
-            },
+          },
           false,
           { version: "0.11.1.1", type: "down" },
         ),
       },
       "0.11.2": {
-          up: compat.migrations.updateConfig(
-            (config) => {
-                if (
-                    matches.shape({
-                    advanced: matches.shape({ plugins: matches.shape({ clboss: matches.any }) }),
-                    }).test(config)
-                ) {
-                    if ( config.advanced.plugins.clboss === true ) {
-                        config.advanced.plugins.clboss = { enabled: "enabled", "min-onchain": null, "auto-close": false, zerobasefee: "default", "min-channel": null, "max-channel": null };
-                    } else {
-                        config.advanced.plugins.clboss = { enabled: "disabled" };
-                    }
-                }
-                    return config;
-                },
-            true,
-            { version: "0.11.2", type: "up" },
-          ),
-          down: compat.migrations.updateConfig(
-            (config) => {
-              if (
-                  matches.shape({
-                  advanced: matches.shape({ plugins: matches.shape({ clboss: matches.any }) }),
-                  }).test(config)
-              ) {
-                  delete config.advanced.plugins.clboss;
+        up: compat.migrations.updateConfig(
+          (config, effects) => {
+            effects.warn(`Up 0.11.2 ${JSON.stringify(config)}`);
+            effects.warn("Migrating from version 0.11.1.1 to 0.11.2");
+            if (
+              matches.shape({
+                advanced: matches.shape({
+                  plugins: matches.shape({ clboss: matches.any }),
+                }),
+              }).test(config)
+            ) {
+              if (config.advanced.plugins.clboss === true) {
+                config.advanced.plugins.clboss = {
+                  enabled: "enabled",
+                  "min-onchain": null,
+                  "auto-close": false,
+                  zerobasefee: "default",
+                  "min-channel": null,
+                  "max-channel": null,
+                };
+              } else {
+                config.advanced.plugins.clboss = { enabled: "disabled" };
               }
-              return config;
-              },
-            false,
-            { version: "0.11.2", type: "down" },
-          ),
-        },
+            }
+            return config;
+          },
+          true,
+          { version: "0.11.2", type: "up" },
+        ),
+        down: compat.migrations.updateConfig(
+          (config, effects) => {
+            effects.warn(`Down 0.11.2 ${JSON.stringify(config)}`);
+            if (
+              matches.shape({
+                advanced: matches.shape({
+                  plugins: matches.shape({ clboss: matches.any }),
+                }),
+              }).test(config)
+            ) {
+              delete config.advanced.plugins.clboss;
+            }
+            return config;
+          },
+          false,
+          { version: "0.11.2", type: "down" },
+        ),
+      },
     },
     "0.11.2",
   );

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -7,28 +7,24 @@ export const migration: T.ExpectedExports.migration = compat.migrations
       // 0.11.1: no migration needed
       "0.11.1.1": {
         up: compat.migrations.updateConfig(
-          (config, effects) => {
-            effects.error(`BLUJ Up 0.11.1.1 ${JSON.stringify(config)}`)
+          (config) => {
             if (
               matches.shape({
-                advanced: matches.shape({ plugins: matches.any }),
+                advanced: matches.shape({ plugins: matches.shape ({ clboss: matches.unknown }, ["clboss"]) }),
               }).test(config)
             ) {
               config.advanced.plugins.clboss = false;
             }
             return config;
           },
-          false, // want to kick user to needs config so they see the new clboss config option
+          true,
           { version: "0.11.1.1", type: "up" },
         ),
         down: compat.migrations.updateConfig(
-          (config, effects) => {
-            effects.error(`BLUJ Down 0.11.1.1 ${JSON.stringify(config)}`)
+          (config) => {
             if (
               matches.shape({
-                advanced: matches.shape({
-                  plugins: matches.shape({ clboss: matches.any }),
-                }),
+                advanced: matches.shape({ plugins: matches.shape ({ clboss: matches.unknown } ) }),
               }).test(config)
             ) {
               delete config.advanced.plugins.clboss;
@@ -41,12 +37,11 @@ export const migration: T.ExpectedExports.migration = compat.migrations
       },
       "0.11.2": {
         up: compat.migrations.updateConfig(
-          (config, effects) => {
-            effects.error(`BLUJ Up 0.11.2 ${JSON.stringify(config)}`)
+          (config) => {
             if (
               matches.shape({
                 advanced: matches.shape({
-                  plugins: matches.shape({ clboss: matches.any }),
+                  plugins: matches.shape({ clboss: matches.unknown }),
                 }),
               }).test(config)
             ) {
@@ -69,8 +64,7 @@ export const migration: T.ExpectedExports.migration = compat.migrations
           { version: "0.11.2", type: "up" },
         ),
         down: compat.migrations.updateConfig(
-          (config, effects) => {
-            effects.error(`BLUJ down 0.11.2 ${JSON.stringify(config)}`)
+          (config) => {
             if (
               matches.shape({
                 advanced: matches.shape({
@@ -78,11 +72,11 @@ export const migration: T.ExpectedExports.migration = compat.migrations
                 }),
               }).test(config)
             ) {
-              delete config.advanced.plugins.clboss;
-            }
+                config.advanced.plugins.clboss = config.advanced.plugins.clboss.enabled === "enabled";
+              }
             return config;
           },
-          false,
+          true,
           { version: "0.11.2", type: "down" },
         ),
       },

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -1,0 +1,74 @@
+import { compat, matches, types as T } from "../deps.ts";
+
+export const migration: T.ExpectedExports.migration = compat.migrations
+  .fromMapping(
+    {
+      // 0.10.2.1: initial version
+      // 0.11.1: no migration needed
+      "0.11.1.1": {
+        up: compat.migrations.updateConfig(
+          (config) => {
+            if (
+              matches.shape({
+                advanced: matches.shape({ plugins: matches.any }),
+              }).test(config)
+            ) {
+              config.advanced.plugins.clboss = false;
+            }
+            return config;
+          },
+          false, // want to kick user to needs config so they see the new clboss config option
+          { version: "0.11.1.1", type: "up" },
+        ),
+        down: compat.migrations.updateConfig(
+          (config) => {
+            if (
+                matches.shape({
+                advanced: matches.shape({ plugins: matches.shape({ clboss: matches.any }) }),
+                }).test(config)
+            ) {
+                delete config.advanced.plugins.clboss;
+            }
+            return config;
+            },
+          false,
+          { version: "0.11.1.1", type: "down" },
+        ),
+      },
+      "0.11.2": {
+          up: compat.migrations.updateConfig(
+            (config) => {
+                if (
+                    matches.shape({
+                    advanced: matches.shape({ plugins: matches.shape({ clboss: matches.any }) }),
+                    }).test(config)
+                ) {
+                    if ( config.advanced.plugins.clboss === true ) {
+                        config.advanced.plugins.clboss = { enabled: "enabled", "min-onchain": null, "auto-close": false, zerobasefee: "default", "min-channel": null, "max-channel": null };
+                    } else {
+                        config.advanced.plugins.clboss = { enabled: "disabled" };
+                    }
+                }
+                    return config;
+                },
+            true,
+            { version: "0.11.2", type: "up" },
+          ),
+          down: compat.migrations.updateConfig(
+            (config) => {
+              if (
+                  matches.shape({
+                  advanced: matches.shape({ plugins: matches.shape({ clboss: matches.any }) }),
+                  }).test(config)
+              ) {
+                  delete config.advanced.plugins.clboss;
+              }
+              return config;
+              },
+            false,
+            { version: "0.11.2", type: "down" },
+          ),
+        },
+    },
+    "0.11.2",
+  );

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -8,8 +8,7 @@ export const migration: T.ExpectedExports.migration = compat.migrations
       "0.11.1.1": {
         up: compat.migrations.updateConfig(
           (config, effects) => {
-            effects.warn(`Up 0.11.1.1 ${JSON.stringify(config)}`);
-            effects.warn("UP 0.11.1.1");
+            effects.error(`BLUJ Up 0.11.1.1 ${JSON.stringify(config)}`)
             if (
               matches.shape({
                 advanced: matches.shape({ plugins: matches.any }),
@@ -24,8 +23,7 @@ export const migration: T.ExpectedExports.migration = compat.migrations
         ),
         down: compat.migrations.updateConfig(
           (config, effects) => {
-            effects.warn(`Down 0.11.1.1 ${JSON.stringify(config)}`);
-            effects.warn("THIS IS A TEST OF THE EMERGENCY BROADCASTING SYSTEM");
+            effects.error(`BLUJ Down 0.11.1.1 ${JSON.stringify(config)}`)
             if (
               matches.shape({
                 advanced: matches.shape({
@@ -44,8 +42,7 @@ export const migration: T.ExpectedExports.migration = compat.migrations
       "0.11.2": {
         up: compat.migrations.updateConfig(
           (config, effects) => {
-            effects.warn(`Up 0.11.2 ${JSON.stringify(config)}`);
-            effects.warn("Migrating from version 0.11.1.1 to 0.11.2");
+            effects.error(`BLUJ Up 0.11.2 ${JSON.stringify(config)}`)
             if (
               matches.shape({
                 advanced: matches.shape({
@@ -73,7 +70,7 @@ export const migration: T.ExpectedExports.migration = compat.migrations
         ),
         down: compat.migrations.updateConfig(
           (config, effects) => {
-            effects.warn(`Down 0.11.2 ${JSON.stringify(config)}`);
+            effects.error(`BLUJ down 0.11.2 ${JSON.stringify(config)}`)
             if (
               matches.shape({
                 advanced: matches.shape({

--- a/scripts/services/properties.ts
+++ b/scripts/services/properties.ts
@@ -1,4 +1,4 @@
-import { matches, YAML, types as T, exists } from "../deps.ts";
+import { matches, YAML, types as T, util } from "../deps.ts";
 import { lazy } from "../models/lazy.ts";
 import { setConfigMatcher } from "../models/setConfig.ts";
 import { getAlias } from "./getAlias.ts";
@@ -27,13 +27,13 @@ const noPropertiesFound: T.ResultType<T.Properties> = {
 } as const
 
 export const properties: T.ExpectedExports.properties = async (effects: T.Effects) => {
-  if (await exists(effects, {
+  if (await util.exists(effects, {
     volumeId: "main",
     path: "start9/lightningGetInfo",
   }) === false) {
     return noPropertiesFound;
   }
-  if (await exists(effects, {
+  if (await util.exists(effects, {
     volumeId: "main",
     path: "start9/peerTorAddress",
   }) === false) {

--- a/scripts/services/properties.ts
+++ b/scripts/services/properties.ts
@@ -1,14 +1,13 @@
-import { matches, YAML, types as T, util } from "../deps.ts";
+import { matches, types as T, util, YAML } from "../deps.ts";
 import { lazy } from "../models/lazy.ts";
 import { setConfigMatcher } from "../models/setConfig.ts";
 import { getAlias } from "./getAlias.ts";
-const { shape, string, } = matches;
+const { shape, string } = matches;
 
 const nodeInfoMatcher = shape({
   id: string,
   alias: string,
-}, ['alias']);
-
+}, ["alias"]);
 
 const noPropertiesFound: T.ResultType<T.Properties> = {
   result: {
@@ -20,23 +19,29 @@ const noPropertiesFound: T.ResultType<T.Properties> = {
         qr: false,
         copyable: false,
         masked: false,
-        description: "Fallback Message When Properties could not be found"
-      }
-    }
-  }
-} as const
+        description: "Fallback Message When Properties could not be found",
+      },
+    },
+  },
+} as const;
 
-export const properties: T.ExpectedExports.properties = async (effects: T.Effects) => {
-  if (await util.exists(effects, {
-    volumeId: "main",
-    path: "start9/lightningGetInfo",
-  }) === false) {
+export const properties: T.ExpectedExports.properties = async (
+  effects: T.Effects,
+) => {
+  if (
+    await util.exists(effects, {
+      volumeId: "main",
+      path: "start9/lightningGetInfo",
+    }) === false
+  ) {
     return noPropertiesFound;
   }
-  if (await util.exists(effects, {
-    volumeId: "main",
-    path: "start9/peerTorAddress",
-  }) === false) {
+  if (
+    await util.exists(effects, {
+      volumeId: "main",
+      path: "start9/peerTorAddress",
+    }) === false
+  ) {
     return noPropertiesFound;
   }
 
@@ -44,7 +49,7 @@ export const properties: T.ExpectedExports.properties = async (effects: T.Effect
     await effects.readJsonFile({
       volumeId: "main",
       path: "start9/lightningGetInfo",
-    })
+    }),
   );
   const peerTorAddress = await effects
     .readFile({
@@ -57,8 +62,8 @@ export const properties: T.ExpectedExports.properties = async (effects: T.Effect
       await effects.readFile({
         path: "start9/config.yaml",
         volumeId: "main",
-      })
-    )
+      }),
+    ),
   );
   const macaroonBase64 = lazy(() =>
     effects.readFile({
@@ -73,34 +78,33 @@ export const properties: T.ExpectedExports.properties = async (effects: T.Effect
     })
   );
 
-  const rpcProperties: T.PackagePropertiesV2 = !config.rpc.enabled
-    ? {}
-    : {
-      "Quick Connect URL": {
-        type: "string",
-        value: `clightning-rpc://${config.rpc.user}:${config.rpc.password}@${peerTorAddress}:8080`,
-        description: "A convenient way to connect a wallet to a remote node",
-        copyable: true,
-        qr: true,
-        masked: true,
-      },
-      "RPC Username": {
-        type: "string",
-        value: config.rpc.user,
-        description: "Username for RPC connections",
-        copyable: true,
-        qr: false,
-        masked: true,
-      },
-      "RPC Password": {
-        type: "string",
-        value: config.rpc.password,
-        description: "Password for RPC connections",
-        copyable: true,
-        qr: false,
-        masked: true,
-      },
-    };
+  const rpcProperties: T.PackagePropertiesV2 = !config.rpc.enabled ? {} : {
+    "Quick Connect URL": {
+      type: "string",
+      value:
+        `clightning-rpc://${config.rpc.user}:${config.rpc.password}@${peerTorAddress}:8080`,
+      description: "A convenient way to connect a wallet to a remote node",
+      copyable: true,
+      qr: true,
+      masked: true,
+    },
+    "RPC Username": {
+      type: "string",
+      value: config.rpc.user,
+      description: "Username for RPC connections",
+      copyable: true,
+      qr: false,
+      masked: true,
+    },
+    "RPC Password": {
+      type: "string",
+      value: config.rpc.password,
+      description: "Password for RPC connections",
+      copyable: true,
+      qr: false,
+      masked: true,
+    },
+  };
 
   const restProperties: T.PackagePropertiesV2 = !config.advanced.plugins.rest
     ? {}
@@ -116,7 +120,8 @@ export const properties: T.ExpectedExports.properties = async (effects: T.Effect
       "Rest API Macaroon": {
         type: "string",
         value: await macaroonBase64.val(),
-        description: "The macaroon that grants access to your node's REST API plugin",
+        description:
+          "The macaroon that grants access to your node's REST API plugin",
         copyable: true,
         qr: false,
         masked: true,
@@ -124,20 +129,22 @@ export const properties: T.ExpectedExports.properties = async (effects: T.Effect
       "Rest API Macaroon (Hex)": {
         type: "string",
         value: await hexMacaroon.val(),
-        description: "The macaroon that grants access to your node's REST API plugin, in hexadecimal format",
+        description:
+          "The macaroon that grants access to your node's REST API plugin, in hexadecimal format",
         copyable: true,
         qr: false,
         masked: true,
       },
     };
-  const alias = await getAlias(effects, config)
+  const alias = await getAlias(effects, config);
   const result: T.Properties = {
     version: 2,
     data: {
       "Node Id": {
         type: "string",
         value: nodeInfo.id,
-        description: "The node identifier that can be used for connecting to other nodes",
+        description:
+          "The node identifier that can be used for connecting to other nodes",
         copyable: true,
         qr: false,
         masked: false,
@@ -162,5 +169,5 @@ export const properties: T.ExpectedExports.properties = async (effects: T.Effect
       ...restProperties,
     },
   };
-  return { result }
-}
+  return { result };
+};

--- a/scripts/services/setConfig.ts
+++ b/scripts/services/setConfig.ts
@@ -1,4 +1,4 @@
-import { YAML, matches, types as T, compat } from "../deps.ts";
+import { compat, matches, types as T, YAML } from "../deps.ts";
 import { SetConfig, setConfigMatcher } from "../models/setConfig.ts";
 import { Alias, getAlias } from "./getAlias.ts";
 
@@ -15,10 +15,10 @@ const matchConfig = shape({
         {
           "onion-messages": boolean,
           offers: boolean,
-        }
-      )
+        },
+      ),
     },
-  )
+  ),
 });
 const configRules: Array<Check> = [
   {
@@ -27,7 +27,8 @@ const configRules: Array<Check> = [
         return "Config is not the correct shape";
       }
       const hasOffers = config.advanced.experimental.offers;
-      const hasOnionMessagesAndOffers = config.advanced.experimental["onion-messages"] && hasOffers;
+      const hasOnionMessagesAndOffers =
+        config.advanced.experimental["onion-messages"] && hasOffers;
       const doesntHaveOffers = !hasOffers;
       if (hasOnionMessagesAndOffers || doesntHaveOffers) return;
       return `You must enable 'Onion Messages' if you wish to enable 'Offers'`;
@@ -45,7 +46,7 @@ function checkConfigRules(config: T.Config): T.KnownError | void {
 }
 
 function urlParse(input: string) {
-  const url = new URL(input)
+  const url = new URL(input);
   const [, _protocol, host, port] = Array.from(regexUrl.exec(input) || []);
   return {
     host,
@@ -53,7 +54,12 @@ function urlParse(input: string) {
   };
 }
 async function createWaitForService(effects: T.Effects, config: SetConfig) {
-  const { bitcoin_rpc_host, bitcoin_rpc_pass, bitcoin_rpc_port, bitcoin_rpc_user } = userInformation(config);
+  const {
+    bitcoin_rpc_host,
+    bitcoin_rpc_pass,
+    bitcoin_rpc_port,
+    bitcoin_rpc_user,
+  } = userInformation(config);
   await effects.writeFile({
     path: "start9/waitForStart.sh",
     toWrite: `
@@ -126,17 +132,28 @@ function userInformation(config: SetConfig) {
 }
 
 function configMaker(alias: Alias, config: SetConfig) {
-  const { bitcoin_rpc_host, bitcoin_rpc_pass, bitcoin_rpc_port, bitcoin_rpc_user } = userInformation(config);
+  const {
+    bitcoin_rpc_host,
+    bitcoin_rpc_pass,
+    bitcoin_rpc_port,
+    bitcoin_rpc_user,
+  } = userInformation(config);
   const rpcBind = config.rpc.enabled ? "0.0.0.0:8080" : "127.0.0.1:8080";
   const enableWumbo = config.advanced["wumbo-channels"] ? "large-channels" : "";
-  const enableExperimentalDualFund = config.advanced.experimental["dual-fund"] ? "experimental-dual-fund" : "";
-  const enableExperimentalOnionMessages = config.advanced.experimental["onion-messages"]
-    ? "experimental-onion-messages"
+  const enableExperimentalDualFund = config.advanced.experimental["dual-fund"]
+    ? "experimental-dual-fund"
     : "";
-  const enableExperimentalOffers = config.advanced.experimental.offers ? "experimental-offers" : "";
-  const enableExperimentalShutdownWrongFunding = config.advanced.experimental["shutdown-wrong-funding"]
-    ? "experimental-shutdown-wrong-funding"
+  const enableExperimentalOnionMessages =
+    config.advanced.experimental["onion-messages"]
+      ? "experimental-onion-messages"
+      : "";
+  const enableExperimentalOffers = config.advanced.experimental.offers
+    ? "experimental-offers"
     : "";
+  const enableExperimentalShutdownWrongFunding =
+    config.advanced.experimental["shutdown-wrong-funding"]
+      ? "experimental-shutdown-wrong-funding"
+      : "";
   const enableHttpPlugin = config.advanced.plugins.http
     ? "plugin=/usr/local/libexec/c-lightning/plugins/c-lightning-http-plugin"
     : "";
@@ -190,15 +207,18 @@ ${enableRestPlugin}
 ${enableClbossPlugin}`;
 }
 
-export const setConfig: T.ExpectedExports.setConfig = async (effects: T.Effects, input: T.Config) => {
+export const setConfig: T.ExpectedExports.setConfig = async (
+  effects: T.Effects,
+  input: T.Config,
+) => {
   const config = setConfigMatcher.unsafeCast(input);
   await checkConfigRules(config);
   const alias = await getAlias(effects, config);
 
   await effects.createDir({
-    path: 'start9',
-    volumeId: 'main'
-  })
+    path: "start9",
+    volumeId: "main",
+  });
 
   await effects.writeFile({
     path: "config.main",
@@ -207,5 +227,5 @@ export const setConfig: T.ExpectedExports.setConfig = async (effects: T.Effects,
   });
 
   await createWaitForService(effects, config);
-  return await compat.setConfig(effects, input)
-}
+  return await compat.setConfig(effects, input);
+};


### PR DESCRIPTION
Testing upstream commit b624c530515b3966ae08b740eac35bbec19da5de on my prodbox to see if the crashes are fixed. So far, so good.

Need to wait for actual upstream release before releasing this?

Edit: also added CLBOSS config options (number 2 on this list https://github.com/Start9Labs/c-lightning-wrapper/issues/50)

~~TODO: We have the option of waiting until upstream cuts an official release tag, in which case I have time to implement CLBOSS properties and actions (the rest of #50). Or we can just go to prod with this.~~

~~TODO: @Blu-J is writing a "deep set" utility. We should switch to using that in the js migrations as soon as that's ready.~~

Edit: moving the TODOs above to a new release, [0.11.2.1](https://github.com/Start9Labs/s9-services/issues/60)