### PR TITLE
Bug fix: Rune generation

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -171,7 +171,7 @@ commando_rune_request() {
   cat <<EOF
 {
   "jsonrpc": "2.0",
-  "id": 1,
+  "id": 2,
   "method": "commando-rune",
   "params": [null, [["For Application#"]]]
 }
@@ -182,7 +182,7 @@ commando_datastore_request() {
   cat <<EOF
 {
   "jsonrpc": "2.0",
-  "id": 1,
+  "id": 3,
   "method": "datastore",
   "params": [["commando", "runes", "$UNIQUE_ID"], "$RUNE"]
 }
@@ -190,20 +190,45 @@ EOF
 }
 
 generate_new_rune() {
-  # Send 'commando-rune' request
-  RUNE_RESPONSE=$( (echo "$(commando_rune_request)"; sleep 1) | socat - UNIX-CONNECT:"$LIGHTNING_RPC")
-  RUNE=$(echo "$RUNE_RESPONSE" | jq -r '.result.rune')
-  UNIQUE_ID=$(echo "$RUNE_RESPONSE" | jq -r '.result.unique_id')
-  # Save rune in env file
-  echo "LIGHTNING_RUNE=\"$RUNE\"" >> $COMMANDO_CONFIG
-  echo "$RUNE"
-  # This will fail for v>23.05
-  DATASTORE_RESPONSE=$( (echo "$(commando_datastore_request)"; sleep 1) | socat - UNIX-CONNECT:"$LIGHTNING_RPC") > /dev/null
+  COUNTER=0
+  RUNE=""
+  while { [ "$RUNE" = "" ] || [ "$RUNE" = "null" ]; } && [ $COUNTER -lt 10 ]; do
+    # Send 'commando-rune' request
+    echo "Generating rune attempt: $COUNTER"
+    COUNTER=$((COUNTER+1))
+
+    RUNE_RESPONSE=$( (echo "$(commando_rune_request)"; sleep 2) | socat - UNIX-CONNECT:"$LIGHTNING_RPC")
+
+    RUNE=$(echo "$RUNE_RESPONSE" | jq -r '.result.rune')
+    UNIQUE_ID=$(echo "$RUNE_RESPONSE" | jq -r '.result.unique_id')
+    echo "RUNE_RESPONSE"
+    echo "$RUNE_RESPONSE"
+    echo "RUNE"
+    echo "$RUNE"
+
+    if [ "$RUNE" != "" ] && [ "$RUNE" != "null" ]; then
+      # Save rune in env file
+      echo "LIGHTNING_RUNE=\"$RUNE\"" >> "$COMMANDO_CONFIG"
+    fi
+
+    if [ "$UNIQUE_ID" != "" ] &&  [ "$UNIQUE_ID" != "null" ]; then
+      # This will fail for v>23.05
+      DATASTORE_RESPONSE=$( (echo "$(commando_datastore_request)"; sleep 1) | socat - UNIX-CONNECT:"$LIGHTNING_RPC") > /dev/null
+    fi
+  done
+  if [ $COUNTER -eq 10 ] && [ "$RUNE" = "" ]; then
+    echo "Error: Unable to generate rune for application authentication!"
+  fi
 }
 
 # Read existing pubkey
 if [ -f "$COMMANDO_CONFIG" ]; then
-  EXISTING_PUBKEY=$(head -n1 $COMMANDO_CONFIG)
+  EXISTING_PUBKEY=$(head -n1 "$COMMANDO_CONFIG")
+  EXISTING_RUNE=$(sed -n "2p" "$COMMANDO_CONFIG")
+  echo "EXISTING_PUBKEY"
+  echo "$EXISTING_PUBKEY"
+  echo "EXISTING_RUNE"
+  echo "$EXISTING_RUNE"
 fi
 
 # Getinfo from CLN
@@ -219,11 +244,14 @@ LIGHTNING_PUBKEY="$(jq -n "$GETINFO_RESPONSE" | jq -r '.result.id')"
 echo "$LIGHTNING_PUBKEY"
 
 # Compare existing pubkey with current
-if [ "$EXISTING_PUBKEY" != "LIGHTNING_PUBKEY=\"$LIGHTNING_PUBKEY\"" ]; then
-  # Pubkey changed; rewrite new data on the file.
-  echo "Pubkey mismatched; Rewriting the data."
-  cat /dev/null > $COMMANDO_CONFIG
-  echo "LIGHTNING_PUBKEY=\"$LIGHTNING_PUBKEY\"" >> $COMMANDO_CONFIG
+if [ "$EXISTING_PUBKEY" != "LIGHTNING_PUBKEY=\"$LIGHTNING_PUBKEY\"" ] ||
+  [ "$EXISTING_RUNE" = "" ] || 
+  [ "$EXISTING_RUNE" = "LIGHTNING_RUNE=\"\"" ] ||
+  [ "$EXISTING_RUNE" = "LIGHTNING_RUNE=\"null\"" ]; then
+  # Pubkey changed or missing rune; rewrite new data on the file.
+  echo "Pubkey mismatched or missing rune; Rewriting the data."
+  cat /dev/null > "$COMMANDO_CONFIG"
+  echo "LIGHTNING_PUBKEY=\"$LIGHTNING_PUBKEY\"" >> "$COMMANDO_CONFIG"
   generate_new_rune
 else
   echo "Pubkey matches with existing pubkey."


### PR DESCRIPTION
- Increased wait time from 1 to 2 seconds for commando_rune_request.
- Added empty rune check to fix current broken applications.
- Added loop to try rune generation for 10 times before failing completely.
- If the rune is not generated even after 10 tries (very unlikely), the application will throw error but core lightning will still go up.