### PR TITLE
fix: set clnrest interface protocol to https

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -126,7 +126,7 @@ interfaces:
     protocols:
       - tcp
       - lightning
-   clnrest:
+  clnrest:
     name: CLNRest
     description: CLNRest is a lightweight Python-based built-in Core Lightning plugin (from v23.08) that transforms RPC calls into a REST service.
     tor-config:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -126,7 +126,7 @@ interfaces:
     protocols:
       - tcp
       - lightning
-  clnrest:
+   clnrest:
     name: CLNRest
     description: CLNRest is a lightweight Python-based built-in Core Lightning plugin (from v23.08) that transforms RPC calls into a REST service.
     tor-config:
@@ -139,7 +139,7 @@ interfaces:
     ui: false
     protocols:
       - tcp
-      - http
+      - https
   watchtower:
     name: TEOS Watchtower API
     description: The Eye of Satoshi is a Lightning watchtower compliant with BOLT13, written in Rust.


### PR DESCRIPTION
## Summary

- The `clnrest` interface in `manifest.yaml` already has `ssl: true` in its `lan-config`, meaning it serves over TLS
- However, `protocols` listed `http` instead of `https`, which is inconsistent and misleading
- This PR corrects it to `https`

Closes #160