### PR TITLE
Bump CLN to v26.04.1, start-sdk to 1.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,3 @@
-## How the upstream version is pulled
-- Image `lightning` is `dockerBuild` from root
-- Has submodules: `plugins/`, `clboss/`, `rust-teos/` — may need updating with upstream
-- Sidecar `ui` image: dockerTag `ghcr.io/elementsproject/cln-application:<version>`
+# CLAUDE.md
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the doc map and contribution workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,53 @@
 # Contributing
 
-## Building and Development
+This repo packages [Core Lightning](https://github.com/ElementsProject/lightning) for StartOS.
 
-See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for complete environment setup and build instructions.
+## Documentation — keep it in sync
 
-### Quick Start
+- **`README.md`** — what this package is and how it's built (image, volumes, interfaces). For developers and AI assistants.
+- **`instructions.md`** — the user-facing instructions packed into the `.s9pk` and shown on the **Instructions** tab in StartOS, for the person running the service.
+- **`CONTRIBUTING.md`** — this file.
+- **`CLAUDE.md`** — operating rules for AI developers working in this repo.
+
+**Any code change that warrants it must update `README.md` and `instructions.md` in the same change** — a new or renamed action, an added or removed volume / port / interface / dependency, a changed default, a new limitation, any altered user-visible behavior. Don't defer: a package that ships with a stale README or stale instructions is not done, even if the code is perfect. Content rules live in the packaging guide: [Writing READMEs](https://docs.start9.com/packaging/writing-readmes.html) and [Writing Service Instructions](https://docs.start9.com/packaging/writing-instructions.html).
+
+## Building
+
+See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for environment setup, then:
 
 ```bash
-# Install dependencies
-npm ci
-
-# Build universal package
-make
+npm ci    # install dependencies
+make      # build the universal .s9pk
 ```
 
-## How to Contribute
+## Updating the upstream version
 
-1. Fork the repository and create a branch from `master`
-2. Make your changes
-3. Open a pull request to `master`
+Core Lightning is built from a custom `Dockerfile` (the `lightning` image) layered on top of the official `elementsproject/lightningd` image, plus a sidecar `ui` image pulled by tag. Several upstream components feed into the build, and a bump usually touches more than one.
+
+### lightningd
+
+1. Update the `FROM elementsproject/lightningd:v<version>` tag in `Dockerfile`.
+2. Bump `version` in the file under `startos/versions/`, renaming it to the new version string. A new version file is only needed when the bump carries an `up`/`down` migration, or when you want the old release notes preserved in git history — see [Versions](https://docs.start9.com/packaging/versions.html).
+3. Update `releaseNotes` to summarize what changed for the user.
+
+### CLN Application (Web UI)
+
+Bump the `dockerTag` for the `ui` image in `startos/manifest/index.ts` to `ghcr.io/elementsproject/cln-application:<new version>`.
+
+### Bundled plugins
+
+- **CLBOSS** lives at the `clboss/` git submodule. To bump it: `cd clboss && git fetch && git checkout <ref> && cd .. && git add clboss`.
+- **TEOS** (watchtower server + client plugin) lives at the `rust-teos/` git submodule. Bump the same way.
+- The miscellaneous **`plugins/`** submodule pins the set of upstream plugin sources used elsewhere in the build; bump it the same way when one of those plugins needs an update.
+- **Sling** is downloaded as a prebuilt binary inside the Dockerfile. Update the `SLING_VERSION` ARG in `Dockerfile` to bump it.
+
+### After bumping
+
+1. Rebuild (`make`), sideload the `.s9pk`, and confirm it starts.
+2. Review `README.md` and `instructions.md` for anything the bump changed.
+
+## How to contribute
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes — including the doc updates above.
+3. Open a pull request to `master`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN cargo install --locked --path teos && \
     cargo install --locked --path watchtower-plugin
 
 # Final stage - simplified
-FROM elementsproject/lightningd:v25.12.1 AS final
+FROM elementsproject/lightningd:v26.04.1 AS final
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libev-dev libcurl4-gnutls-dev libsqlite3-dev libunwind-dev && \

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,58 @@
+# Core Lightning
+
+## Documentation
+
+- [Core Lightning documentation](https://docs.corelightning.org/docs/home) — the upstream operator and developer reference.
+
+## What you get on StartOS
+
+- A **Core Lightning** node (`lightningd`) running mainnet, with an auto-created wallet on first start.
+- A **Web UI** (CLN Application) for managing channels, payments, and invoices, with its own password set on first access.
+- A **JSON-RPC** interface, a **gRPC** interface, and (when enabled) a **CLNrest** REST interface that publishes a URL containing a pre-generated rune for wallet apps.
+- An optional **Clams Websocket** endpoint for Clams Remote.
+- A bundled set of plugins built into the image: **CLBOSS** (automated channel management), **Sling** (channel rebalancing), and **TEOS** for watchtower client and server functionality.
+- A required dependency on **Bitcoin Core** — install and fully sync Bitcoin Core first; CLN will not start without it.
+
+## Getting set up
+
+1. Install and fully sync **Bitcoin Core** if you haven't already.
+2. Start Core Lightning. The wallet is created automatically on first start; no seed phrase setup is required.
+3. Open the **Web UI** interface and set the UI password on first access. Save this password — it is independent of your StartOS credentials.
+4. To connect a wallet app or other client, run the **Create Rune** action to generate an unrestricted rune, or use the rune embedded in the **CLNrest** interface URL.
+
+## Using Core Lightning
+
+### Interfaces
+
+- **Web UI** — the CLN Application web dashboard for day-to-day node operation.
+- **RPC** — JSON-RPC over HTTP for `lightning-cli` and scripts.
+- **Peer** — the Lightning peer-to-peer port; share this address with peers who want to open channels with you.
+- **grpc** — the gRPC API for apps and plugins that prefer typed RPC.
+- **CLNrest** — REST API. When enabled, the published URL contains the rune wallet apps need to authenticate; the scheme is `clnrest://`.
+- **Clams Websocket** — websocket endpoint for Clams Remote, shown when the `clams-remote-websocket` option is on.
+- **TEOS Watchtower** — present only when the watchtower server is enabled.
+
+### Actions
+
+- **Node Info** — display your node ID and peer URI(s) to share with channel partners.
+- **Display BIP-39 Seed** — show the 12-word BIP-39 seed for on-chain recovery. Hidden if your wallet predates BIP-39 support in CLN; the seed alone does not recover channel state.
+- **Create Rune** — generate an unrestricted rune for app integrations.
+- **Other Config Options** — set alias, color, fee base and rate, minimum channel capacity, funding confirmations, Tor-only mode, and Clams Websocket.
+- **Plugins** — enable or disable CLNrest, Sling, and CLBOSS, with sub-settings for CLBOSS (min on-chain reserve, auto-close, zero base fee, channel size limits).
+- **Experimental Features** — toggle splicing, shutdown-wrong-funding, and dual funding / liquidity ads (with policy, fuzz percentage, fund probability, and merchant lease-fee settings).
+- **Watchtower Settings** — enable the TEOS watchtower server, enable the watchtower client, and add tower URIs to register with.
+- **Watchtower Info** — visible when the watchtower server is enabled; shows the server URI and stats.
+- **Watchtower Client Info** — visible when at least one tower is configured; shows registered towers and subscription state.
+- **Rescan Blockchain** — rescan the blockchain from a given depth or block height. Useful after restoring an on-chain wallet.
+- **Reset UI Password** — clear the CLN Application UI password so you can set a new one on the next visit.
+- **Delete Gossip Store** — delete a corrupted `gossip_store`; CLN will rebuild it from peers on next start. Available when the service is stopped.
+
+### Backups and restore
+
+StartOS backs up the `main` volume, excluding live database files and the gossip store. After a restore, CLN automatically runs `emergencyrecover` to attempt to recover channel funds via peer cooperation. Recovery is best-effort and depends on peers responding — once channels have resolved, sweep remaining funds to another wallet and reinstall fresh if you want to keep using the node.
+
+## Limitations
+
+- **Mainnet only.** Testnet, signet, and regtest are not exposed.
+- **Bitcoin authentication is cookie-based.** `bitcoin-rpcuser` and `bitcoin-rpcpassword` are intentionally not configurable; CLN uses the mounted Bitcoin Core cookie file.
+- **The `config` file is managed through actions.** Manual edits will be overwritten on the next config sync.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "cln-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3",
+        "@start9labs/start-sdk": "1.5.0",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
         "dotenv": "^17.2.0",
         "node-forge": "^1.3.1"
@@ -52,6 +52,72 @@
       }
     },
     "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@start9labs/start-sdk": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
+      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@types/ini": "^4.1.1",
+        "deep-equality-data-structures": "^2.0.0",
+        "fast-xml-parser": "~5.7.0",
+        "ini": "^5.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "yaml": "^2.8.3",
+        "zod": "4.3.6",
+        "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
+      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/bitcoin-core-startos": {
+      "name": "bitcoin-core",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#b3bc91c970db6822b38228b07b646ec7ad3138fa",
+      "dependencies": {
+        "@start9labs/start-sdk": "1.3.3",
+        "diskusage": "^1.2.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@nodable/entities": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
       "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
@@ -63,7 +129,7 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@start9labs/start-sdk": {
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
       "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
@@ -83,58 +149,25 @@
         "zod-deep-partial": "^1.2.0"
       }
     },
-    "node_modules/@types/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
+    "node_modules/bitcoin-core-startos/node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@vercel/ncc": {
-      "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
-      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
-      "dev": true,
-      "license": "MIT",
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
       "bin": {
-        "ncc": "dist/ncc/cli.js"
-      }
-    },
-    "node_modules/bitcoin-core-startos": {
-      "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#e873695fc4e9fa5a21d13db9b56edbb1dab48d08",
-      "dependencies": {
-        "@start9labs/start-sdk": "1.3.2",
-        "diskusage": "^1.2.0"
-      }
-    },
-    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "^4.3.6",
-        "zod-deep-partial": "^1.2.0"
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/deep-equality-data-structures": {
@@ -158,9 +191,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -176,9 +209,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -187,13 +220,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -202,8 +236,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -246,9 +280,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -305,9 +339,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -321,9 +355,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -381,10 +415,25 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -401,7 +450,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3",
+    "@start9labs/start-sdk": "1.5.0",
     "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
     "dotenv": "^17.2.0",
     "node-forge": "^1.3.1"

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -89,6 +89,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
       alpn: null,
       preferredExternalPort: grpcPort,
       addXForwardedHeaders: false,
+      auth: null,
     },
   })
   const grpc = sdk.createInterface(effects, {
@@ -124,6 +125,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
         alpn: null,
         preferredExternalPort: clnrestPort,
         addXForwardedHeaders: false,
+        auth: null,
       },
     })
 

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -16,7 +16,6 @@ export const manifest = setupManifest({
   upstreamRepo: 'https://github.com/ElementsProject/lightning',
   marketingUrl: 'https://blockstream.com/lightning',
   donationUrl: null,
-  docsUrls: ['https://docs.corelightning.org/docs/home'],
   description: { short, long },
   volumes: ['main'],
   images: {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_25_12_1_9 } from './v25.12.1.9'
+import { v_26_4_1_1 } from './v26.4.1.1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_25_12_1_9,
+  current: v_26_4_1_1,
   other: [],
 })

--- a/startos/versions/v26.4.1.1.ts
+++ b/startos/versions/v26.4.1.1.ts
@@ -3,14 +3,49 @@ import { readFile, rm } from 'fs/promises'
 import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
-export const v_25_12_1_9 = VersionInfo.of({
-  version: '25.12.1:9',
+export const v_26_4_1_1 = VersionInfo.of({
+  version: '26.4.1:1',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.3.3)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.3.3)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.3.3)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.3.3)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.3.3)',
+    en_US: `**Bumps**
+
+- Core Lightning → 26.04.1 (Negative Routing Fees II)
+- @start9labs/start-sdk → 1.5.0
+
+**Internal**
+
+- Adapt to SDK \`AddSslOptions.auth\` requirement.`,
+    es_ES: `**Cambios**
+
+- Core Lightning → 26.04.1 (Tarifas de Enrutamiento Negativas II)
+- @start9labs/start-sdk → 1.5.0
+
+**Interno**
+
+- Adaptación al nuevo requisito \`AddSslOptions.auth\` del SDK.`,
+    de_DE: `**Aktualisierungen**
+
+- Core Lightning → 26.04.1 (Negative Routing-Gebühren II)
+- @start9labs/start-sdk → 1.5.0
+
+**Intern**
+
+- Anpassung an die neue \`AddSslOptions.auth\`-Anforderung des SDK.`,
+    pl_PL: `**Aktualizacje**
+
+- Core Lightning → 26.04.1 (Ujemne opłaty routingowe II)
+- @start9labs/start-sdk → 1.5.0
+
+**Wewnętrzne**
+
+- Dostosowanie do nowego wymogu \`AddSslOptions.auth\` w SDK.`,
+    fr_FR: `**Mises à jour**
+
+- Core Lightning → 26.04.1 (Frais de Routage Négatifs II)
+- @start9labs/start-sdk → 1.5.0
+
+**Interne**
+
+- Adaptation à la nouvelle exigence \`AddSslOptions.auth\` du SDK.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- **Upstream:** Core Lightning v25.12.1 → **v26.04.1** ("Negative Routing Fees II"). Minor-major jump (v25.12 → v26.04 baseline + .1 hotfix).
- **SDK:** `@start9labs/start-sdk` 1.3.3 → **1.5.0**. Adapts the two HTTPS binds (`grpc`, `clnrest`) to the new required `auth: null` field on `AddSslOptions` (breaking change introduced in 1.3.4 — see [SDK changelog](https://github.com/Start9Labs/start-sdk/blob/master/CHANGELOG.md)).
- **Version graph:** renamed the version file in place to `v26.4.1.1.ts`, package version `26.4.1:1`, release notes refreshed in all five locales. No new migration is needed for the `25.12.1:9 → 26.4.1:1` hop — the pre-existing `up` (pre-v25.12 YAML-config conversion) is a no-op for already-migrated installs and is preserved for users coming from very old versions. Package version drops CLN's leading zero (`26.04` → `26.4`) because the SDK's `ValidateExVer` rejects leading-zero numeric components; the upstream tag is pinned verbatim in the Dockerfile and called out in the release notes.

## Notes

- **CLN 26.04 deprecations:** `experimental-splicing` is now deprecated upstream (splicing is on by default) but still accepted — the existing experimental-splicing toggle in the package config keeps working. No fix needed in this PR.
- **CLN 26.04 removals:** `decodepay`, `close` `tx`/`txid` fields, `option_anchors_zero_fee_htlc_tx` feature string, `estimatefeesv1`. None of these are wired into this package's config or actions, so no impact.
- **UI image** `ghcr.io/elementsproject/cln-application:26.04` is already on the latest cln-application tag — left as-is.
- **No new feature work** in this PR. Future opportunities exposed by v26.04 that could justify follow-up:
  - `splicein` / `spliceout` RPCs as Start9 actions
  - `currencyconvert` / `currencyrate` plugin (new fiat conversion)
  - `fronting_nodes` / `payment-fronting-node` config options
  - `bkpr-report` action for flexible bookkeeper summaries
  - Parallel pathfinding tuning via `askrene-max-threads`
- README content is unchanged: splicing/dual-fund/xpay are still listed as experimental in the action surface; that mirrors the package config schema, which still uses the deprecated-but-functional `experimental-*` flags.

## Verification

- `npx tsc --noEmit` — clean
- `npx ncc build startos/index.ts -o ./javascript` — succeeds
- Full `make` not run in this environment (Docker not exercised); the package's TS surface is the change.

## Test plan

- [ ] Build s9pk on a host with Docker (`make`).
- [ ] Install on a clean StartOS box and confirm CLN starts, gRPC + CLNrest interfaces export with the new `auth: null` proxy config, and the wallet flow is unaffected.
- [ ] Upgrade from a `25.12.1:9` install and confirm config survives (the inherited pre-v25.12 migration code is harmless on already-migrated state).