### PR TITLE
chore: bump clboss to 0.16.0, sling to 4.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN autoreconf -i && \
 # sling - download prebuilt binary
 FROM base AS sling
 ARG TARGETARCH
-ARG SLING_VERSION=v3.0.3
+ARG SLING_VERSION=v4.2.1
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* && \
     if [ "$TARGETARCH" = "amd64" ]; then SLING_ARCH=x86_64; else SLING_ARCH=aarch64; fi && \
     curl -fSL "https://github.com/daywalker90/sling/releases/download/${SLING_VERSION}/sling-${SLING_VERSION}-${SLING_ARCH}-linux-gnu.tar.gz" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#132f3e72902ba899713b898b7534c479ccac7363",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.1",
         "diskusage": "^1.2.0"
@@ -397,7 +397,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_26_4_1_1 } from './v26.4.1.1'
+import { v_26_4_1_2 } from './v26.4.1.2'
 
 export const versionGraph = VersionGraph.of({
-  current: v_26_4_1_1,
+  current: v_26_4_1_2,
   other: [],
 })

--- a/startos/versions/v26.4.1.2.ts
+++ b/startos/versions/v26.4.1.2.ts
@@ -3,49 +3,29 @@ import { readFile, rm } from 'fs/promises'
 import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
-export const v_26_4_1_1 = VersionInfo.of({
-  version: '26.4.1:1',
+export const v_26_4_1_2 = VersionInfo.of({
+  version: '26.4.1:2',
   releaseNotes: {
     en_US: `**Bumps**
 
-- Core Lightning → 26.04.1 (Negative Routing Fees II)
-- @start9labs/start-sdk → 1.5.0
-
-**Internal**
-
-- Adapt to SDK \`AddSslOptions.auth\` requirement.`,
+- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
+- sling → 4.2.1`,
     es_ES: `**Cambios**
 
-- Core Lightning → 26.04.1 (Tarifas de Enrutamiento Negativas II)
-- @start9labs/start-sdk → 1.5.0
-
-**Interno**
-
-- Adaptación al nuevo requisito \`AddSslOptions.auth\` del SDK.`,
+- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
+- sling → 4.2.1`,
     de_DE: `**Aktualisierungen**
 
-- Core Lightning → 26.04.1 (Negative Routing-Gebühren II)
-- @start9labs/start-sdk → 1.5.0
-
-**Intern**
-
-- Anpassung an die neue \`AddSslOptions.auth\`-Anforderung des SDK.`,
+- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
+- sling → 4.2.1`,
     pl_PL: `**Aktualizacje**
 
-- Core Lightning → 26.04.1 (Ujemne opłaty routingowe II)
-- @start9labs/start-sdk → 1.5.0
-
-**Wewnętrzne**
-
-- Dostosowanie do nowego wymogu \`AddSslOptions.auth\` w SDK.`,
+- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
+- sling → 4.2.1`,
     fr_FR: `**Mises à jour**
 
-- Core Lightning → 26.04.1 (Frais de Routage Négatifs II)
-- @start9labs/start-sdk → 1.5.0
-
-**Interne**
-
-- Adaptation à la nouvelle exigence \`AddSslOptions.auth\` du SDK.`,
+- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
+- sling → 4.2.1`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/v26.4.1.2.ts
+++ b/startos/versions/v26.4.1.2.ts
@@ -9,23 +9,68 @@ export const v_26_4_1_2 = VersionInfo.of({
     en_US: `**Bumps**
 
 - clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1`,
+- sling → 4.2.1
+
+**Fixes**
+
+- sling now correctly reads CLN's compacted gossip store on v26.04+ (could degrade routing on the previous version).
+
+**Behavior changes**
+
+- clboss internal rebalancing fee cap default dropped from 0.5% to 0.1%.
+- sling no longer accepts your own channels or node id in \`sling-except-chan\`; if you set this manually, remove those entries before upgrading.`,
     es_ES: `**Cambios**
 
 - clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1`,
+- sling → 4.2.1
+
+**Correcciones**
+
+- sling ahora lee correctamente el gossip store compactado de CLN en v26.04+ (podía degradar el enrutamiento en la versión anterior).
+
+**Cambios de comportamiento**
+
+- El tope por defecto de la comisión de rebalanceo interno de clboss se redujo del 0,5% al 0,1%.
+- sling ya no acepta tus propios canales ni tu node id en \`sling-except-chan\`; si los configuraste manualmente, elimina esas entradas antes de actualizar.`,
     de_DE: `**Aktualisierungen**
 
 - clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1`,
+- sling → 4.2.1
+
+**Korrekturen**
+
+- sling liest jetzt den kompaktierten Gossip-Store von CLN auf v26.04+ korrekt (konnte zuvor das Routing beeinträchtigen).
+
+**Verhaltensänderungen**
+
+- Der Standardwert der internen Rebalancing-Gebührenobergrenze von clboss wurde von 0,5 % auf 0,1 % gesenkt.
+- sling akzeptiert keine eigenen Kanäle oder die eigene Node-ID mehr in \`sling-except-chan\`; falls Sie diese manuell gesetzt haben, entfernen Sie die Einträge vor dem Upgrade.`,
     pl_PL: `**Aktualizacje**
 
 - clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1`,
+- sling → 4.2.1
+
+**Poprawki**
+
+- sling poprawnie odczytuje teraz skompaktowany gossip store CLN w wersji v26.04+ (mogło to wcześniej pogarszać routing).
+
+**Zmiany zachowania**
+
+- Domyślny limit opłaty wewnętrznego rebalansowania clboss obniżony z 0,5% do 0,1%.
+- sling nie akceptuje już własnych kanałów ani własnego node id w \`sling-except-chan\`; jeśli ustawiłeś to ręcznie, usuń te wpisy przed aktualizacją.`,
     fr_FR: `**Mises à jour**
 
 - clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1`,
+- sling → 4.2.1
+
+**Corrections**
+
+- sling lit désormais correctement le gossip store compacté de CLN sur v26.04+ (pouvait dégrader le routage dans la version précédente).
+
+**Changements de comportement**
+
+- Le plafond par défaut des frais de rééquilibrage interne de clboss est passé de 0,5 % à 0,1 %.
+- sling n'accepte plus vos propres canaux ni votre node id dans \`sling-except-chan\` ; si vous les avez configurés manuellement, supprimez ces entrées avant la mise à niveau.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Routine maintenance bumps to the two bundled CLN plugins.

- **clboss**: v0.14.1 → v0.16.0 ("Darkness on the Edge of the Mempool"). Adds the Fee Monitor module + new `clboss-feemon-*` RPCs, fixes a crash on non-SRV DNS records, drops two defunct DNS seeds, and adopts C++20. Full changelog: https://github.com/ZmnSCPxj/clboss/blob/v0.16.0/CHANGELOG.md.
- **sling**: v3.0.3 → v4.2.1. ~20× faster gossip reader, ~2× faster route search, new `sling-once`/`sling-stats` subcommands, and now reads `xpay`-layer constraint data on CLN ≥ v24.11. Drops support for CLN ≤ v24.02 — we ship v26.04.1, so no impact. Cln-startos doesn't expose any of the removed sling config options (e.g. `sling-refresh-peers-interval`, `sling-refresh-gossmap-interval`), so no user-config migration is needed.
- **npm update**: refreshes the `bitcoin-core-startos` git pin against its current `master`.

Already current and unchanged:

- Core Lightning upstream stable: v26.04.1 (v26.06rc1 exists but is a release candidate).
- `ghcr.io/elementsproject/cln-application:26.04` UI image: latest tag.
- `@start9labs/start-sdk`: 1.5.1, already on target.
- `rust-teos`: master HEAD is 8 commits ahead of the pinned SHA (CI fixes, an HTTPS-watchtower-client commit, a nix flake). No new release tag; leaving the pin alone for now.

Version bumps to **26.4.1:2**. No migration change — version file renamed in place per the packaging convention.

## Test plan

- [x] `npm run check` passes.
- [x] `make` succeeds (x86_64 + aarch64 .s9pk both produced).
- [ ] Smoke install on a StartOS host (out of scope for this PR; not required by the maintenance workflow).