### PR TITLE
chore: bump start-sdk to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "cln-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "dotenv": "^17.2.0",
         "node-forge": "^1.3.1"
@@ -64,9 +64,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -111,9 +111,9 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#132f3e72902ba899713b898b7534c479ccac7363",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#cfe246bbb5e9806fb4498b02ec9d542452c25b2d",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "diskusage": "^1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "1.5.2",
     "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
     "dotenv": "^17.2.0",
     "node-forge": "^1.3.1"

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_26_4_1_2 } from './v26.4.1.2'
+import { v_26_4_1_3 } from './v26.4.1.3'
 
 export const versionGraph = VersionGraph.of({
-  current: v_26_4_1_2,
+  current: v_26_4_1_3,
   other: [],
 })

--- a/startos/versions/v26.4.1.3.ts
+++ b/startos/versions/v26.4.1.3.ts
@@ -3,74 +3,14 @@ import { readFile, rm } from 'fs/promises'
 import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
-export const v_26_4_1_2 = VersionInfo.of({
-  version: '26.4.1:2',
+export const v_26_4_1_3 = VersionInfo.of({
+  version: '26.4.1:3',
   releaseNotes: {
-    en_US: `**Bumps**
-
-- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1
-
-**Fixes**
-
-- sling now correctly reads CLN's compacted gossip store on v26.04+ (could degrade routing on the previous version).
-
-**Behavior changes**
-
-- clboss internal rebalancing fee cap default dropped from 0.5% to 0.1%.
-- sling no longer accepts your own channels or node id in \`sling-except-chan\`; if you set this manually, remove those entries before upgrading.`,
-    es_ES: `**Cambios**
-
-- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1
-
-**Correcciones**
-
-- sling ahora lee correctamente el gossip store compactado de CLN en v26.04+ (podía degradar el enrutamiento en la versión anterior).
-
-**Cambios de comportamiento**
-
-- El tope por defecto de la comisión de rebalanceo interno de clboss se redujo del 0,5% al 0,1%.
-- sling ya no acepta tus propios canales ni tu node id en \`sling-except-chan\`; si los configuraste manualmente, elimina esas entradas antes de actualizar.`,
-    de_DE: `**Aktualisierungen**
-
-- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1
-
-**Korrekturen**
-
-- sling liest jetzt den kompaktierten Gossip-Store von CLN auf v26.04+ korrekt (konnte zuvor das Routing beeinträchtigen).
-
-**Verhaltensänderungen**
-
-- Der Standardwert der internen Rebalancing-Gebührenobergrenze von clboss wurde von 0,5 % auf 0,1 % gesenkt.
-- sling akzeptiert keine eigenen Kanäle oder die eigene Node-ID mehr in \`sling-except-chan\`; falls Sie diese manuell gesetzt haben, entfernen Sie die Einträge vor dem Upgrade.`,
-    pl_PL: `**Aktualizacje**
-
-- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1
-
-**Poprawki**
-
-- sling poprawnie odczytuje teraz skompaktowany gossip store CLN w wersji v26.04+ (mogło to wcześniej pogarszać routing).
-
-**Zmiany zachowania**
-
-- Domyślny limit opłaty wewnętrznego rebalansowania clboss obniżony z 0,5% do 0,1%.
-- sling nie akceptuje już własnych kanałów ani własnego node id w \`sling-except-chan\`; jeśli ustawiłeś to ręcznie, usuń te wpisy przed aktualizacją.`,
-    fr_FR: `**Mises à jour**
-
-- clboss → 0.16.0 (Darkness on the Edge of the Mempool)
-- sling → 4.2.1
-
-**Corrections**
-
-- sling lit désormais correctement le gossip store compacté de CLN sur v26.04+ (pouvait dégrader le routage dans la version précédente).
-
-**Changements de comportement**
-
-- Le plafond par défaut des frais de rééquilibrage interne de clboss est passé de 0,5 % à 0,1 %.
-- sling n'accepte plus vos propres canaux ni votre node id dans \`sling-except-chan\` ; si vous les avez configurés manuellement, supprimez ces entrées avant la mise à niveau.`,
+    en_US: 'Bumps start-sdk to 1.5.2 (internal).',
+    es_ES: 'Actualiza start-sdk a 1.5.2 (interno).',
+    de_DE: 'Aktualisiert start-sdk auf 1.5.2 (intern).',
+    pl_PL: 'Aktualizacja start-sdk do 1.5.2 (wewnętrzne).',
+    fr_FR: 'Mise à jour de start-sdk vers 1.5.2 (interne).',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` from 1.5.1 → 1.5.2.
- Bumps package revision to `26.4.1:3`; version file renamed in place (no migration).

## SDK changelog scope

1.5.2 fixes `Backups.withPgDump` / `Backups.withMysqlDump` staging — this package only uses `Backups.ofVolumes('main')`, so the fix does not change behavior here. No code adaptations required.

## Upstream status

No upstream bumps available this run — all already at latest:
- Core Lightning v26.04.1
- cln-application v26.04
- clboss v0.16.0
- sling v4.2.1
- rust-teos (no new release since 2023)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `make` produces both `c-lightning_x86_64.s9pk` and `c-lightning_aarch64.s9pk` at version `26.4.1:3` with SDK `1.5.2`