### PR TITLE
fix: run emergency recovery once after restore, not on every restart

### DIFF
--- a/startos/main.ts
+++ b/startos/main.ts
@@ -41,6 +41,18 @@ export const main = sdk.setupMain(async ({ effects }) => {
     await storeJson.merge(effects, { rescan: undefined })
   }
 
+  // `restore` is a one-time trigger set by the post-restore backup hook (backups.ts).
+  // Clear it now — before the reactive store watch near the end of main — so the
+  // emergency-recover oneshot (lightning-cli emergencyrecover) and the "Backup
+  // Restoration Detected" health warning fire exactly once after a restore, not on
+  // every subsequent restart. The local `store.restore` snapshot read above still
+  // drives the oneshot this session; clearing only the on-disk value here mirrors how
+  // `rescan` is handled and keeps the clear ahead of the `.const` watch at line ~288,
+  // so it doesn't re-trigger main.
+  if (store.restore) {
+    await storeJson.merge(effects, { restore: undefined })
+  }
+
   /**
    * ======================== Daemons ========================
    *

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -1,11 +1,10 @@
-import { Daemons, FileHelper } from '@start9labs/start-sdk'
+import { FileHelper } from '@start9labs/start-sdk'
 import { manifest as bitcoinManifest } from 'bitcoin-core-startos/startos/manifest'
 import { readFile, writeFile } from 'fs/promises'
 import { ListTowers } from './actions/watchtower/watchtowerClientInfo'
 import { clnConfig } from './fileModels/config'
 import { storeJson } from './fileModels/store.json'
 import { i18n } from './i18n'
-import { manifest } from './manifest'
 import { sdk } from './sdk'
 import {
   bitcoinDataDir,
@@ -260,77 +259,73 @@ export const main = sdk.setupMain(async ({ effects }) => {
       requires: ['lightningd'],
     })
 
-  let daemons: Daemons<
-    typeof manifest,
-    | 'lightningd'
-    | 'commando-config'
-    | 'cln-application'
-    | 'check-synced'
-    | 'emergency-recover'
-    | 'watchtower-server'
-  > = baseDaemons
-
-  if (store.restore) {
-    daemons = baseDaemons.addOneshot('emergency-recover', {
-      subcontainer: lightningSub,
-      exec: {
-        fn: async () => {
-          await sdk.setHealth(effects, {
-            id: 'restored',
-            name: i18n('Backup Restoration Detected'),
-            message: i18n(
-              'It is not recommended to continue using a Core Lightning node after emergency recovery. All channels will be force-closed and funds swept to the on-chain wallet. Please wait for all channels to resolve, then sweep remaining funds to another wallet. Afterwards, Core Lightning should be uninstalled and re-installed fresh if you would like to continue using it.',
-            ),
-            result: 'failure',
-          })
-          return {
-            command: [
-              'lightning-cli',
-              `--lightning-dir=${rootDir}`,
-              'emergencyrecover',
-            ],
-          }
-        },
-      },
-      requires: ['lightningd'],
-    })
-  }
-
   // restart on changes to store or config
   await storeJson.read().const(effects)
 
-  if (store.watchtowerServer) {
-    daemons = baseDaemons.addDaemon('watchtower-server', {
-      subcontainer: lightningSub,
-      exec: {
-        command: ['teosd', '--datadir=/root/.lightning/.teos'],
-      },
-      ready: {
-        display: i18n('TEOS Watchtower Server'),
-        fn: async () => {
-          const gettowerinfoRes = await lightningSub.exec([
-            'teos-cli',
-            '--datadir=/root/.lightning/.teos',
-            'gettowerinfo',
-          ])
-          if (gettowerinfoRes.exitCode === 0) {
-            return {
-              result: 'success',
-              message: i18n('The Watchtower Server is online'),
-            }
+  // emergency-recover and watchtower-server are added conditionally via thunks so
+  // both can coexist in a single chain. (Previously each `if` rebuilt from
+  // `baseDaemons`, so enabling the watchtower server silently dropped the
+  // emergency-recover oneshot after a restore.)
+  return baseDaemons
+    .addOneshot('emergency-recover', () =>
+      store.restore
+        ? {
+            subcontainer: lightningSub,
+            exec: {
+              fn: async () => {
+                await sdk.setHealth(effects, {
+                  id: 'restored',
+                  name: i18n('Backup Restoration Detected'),
+                  message: i18n(
+                    'It is not recommended to continue using a Core Lightning node after emergency recovery. All channels will be force-closed and funds swept to the on-chain wallet. Please wait for all channels to resolve, then sweep remaining funds to another wallet. Afterwards, Core Lightning should be uninstalled and re-installed fresh if you would like to continue using it.',
+                  ),
+                  result: 'failure',
+                })
+                return {
+                  command: [
+                    'lightning-cli',
+                    `--lightning-dir=${rootDir}`,
+                    'emergencyrecover',
+                  ],
+                }
+              },
+            },
+            requires: ['lightningd'],
           }
+        : null,
+    )
+    .addDaemon('watchtower-server', () =>
+      store.watchtowerServer
+        ? {
+            subcontainer: lightningSub,
+            exec: {
+              command: ['teosd', '--datadir=/root/.lightning/.teos'],
+            },
+            ready: {
+              display: i18n('TEOS Watchtower Server'),
+              fn: async () => {
+                const gettowerinfoRes = await lightningSub.exec([
+                  'teos-cli',
+                  '--datadir=/root/.lightning/.teos',
+                  'gettowerinfo',
+                ])
+                if (gettowerinfoRes.exitCode === 0) {
+                  return {
+                    result: 'success',
+                    message: i18n('The Watchtower Server is online'),
+                  }
+                }
 
-          return {
-            result: 'starting',
-            message: i18n('TEOSd is starting...'),
+                return {
+                  result: 'starting',
+                  message: i18n('TEOSd is starting...'),
+                }
+              },
+            },
+            requires: ['lightningd'],
           }
-        },
-      },
-      requires: ['lightningd'],
-    })
-  }
-
-  return daemons
+        : null,
+    )
     .addOneshot('watchtower-client', {
       subcontainer: lightningSub,
       exec: {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,8 +3,8 @@ import { readFile, rm } from 'fs/promises'
 import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
-export const v_26_4_1_2 = VersionInfo.of({
-  version: '26.4.1:2',
+export const current = VersionInfo.of({
+  version: '26.4.1:3',
   releaseNotes: {
     en_US: `**Bumps**
 
@@ -13,6 +13,7 @@ export const v_26_4_1_2 = VersionInfo.of({
 
 **Fixes**
 
+- Restoring from backup no longer re-runs emergency recovery or re-shows the "Backup Restoration Detected" warning on every restart — it now happens once, right after the restore.
 - sling now correctly reads CLN's compacted gossip store on v26.04+ (could degrade routing on the previous version).
 
 **Behavior changes**
@@ -26,6 +27,7 @@ export const v_26_4_1_2 = VersionInfo.of({
 
 **Correcciones**
 
+- Restaurar desde una copia de seguridad ya no vuelve a ejecutar la recuperación de emergencia ni a mostrar la advertencia «Restauración de copia de seguridad detectada» en cada reinicio: ahora ocurre una sola vez, justo después de la restauración.
 - sling ahora lee correctamente el gossip store compactado de CLN en v26.04+ (podía degradar el enrutamiento en la versión anterior).
 
 **Cambios de comportamiento**
@@ -39,6 +41,7 @@ export const v_26_4_1_2 = VersionInfo.of({
 
 **Korrekturen**
 
+- Das Wiederherstellen aus einem Backup führt die Notfallwiederherstellung nicht mehr bei jedem Neustart erneut aus und zeigt die Warnung „Backup-Wiederherstellung erkannt“ nicht mehr erneut an – es geschieht jetzt einmalig, direkt nach der Wiederherstellung.
 - sling liest jetzt den kompaktierten Gossip-Store von CLN auf v26.04+ korrekt (konnte zuvor das Routing beeinträchtigen).
 
 **Verhaltensänderungen**
@@ -52,6 +55,7 @@ export const v_26_4_1_2 = VersionInfo.of({
 
 **Poprawki**
 
+- Przywracanie z kopii zapasowej nie uruchamia już ponownie odzyskiwania awaryjnego ani nie pokazuje ponownie ostrzeżenia „Wykryto przywracanie z kopii zapasowej” przy każdym restarcie — następuje to teraz raz, zaraz po przywróceniu.
 - sling poprawnie odczytuje teraz skompaktowany gossip store CLN w wersji v26.04+ (mogło to wcześniej pogarszać routing).
 
 **Zmiany zachowania**
@@ -65,6 +69,7 @@ export const v_26_4_1_2 = VersionInfo.of({
 
 **Corrections**
 
+- La restauration depuis une sauvegarde ne relance plus la récupération d'urgence et n'affiche plus l'avertissement « Restauration de sauvegarde détectée » à chaque redémarrage — cela se produit désormais une seule fois, juste après la restauration.
 - sling lit désormais correctement le gossip store compacté de CLN sur v26.04+ (pouvait dégrader le routage dans la version précédente).
 
 **Changements de comportement**

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_26_4_1_2 } from './v26.4.1.2'
+import { current } from './current'
 
 export const versionGraph = VersionGraph.of({
-  current: v_26_4_1_2,
+  current,
   other: [],
 })


### PR DESCRIPTION
## Summary

After restoring from backup, the emergency-recover oneshot (`lightning-cli emergencyrecover`) and the "Backup Restoration Detected" health warning were firing on **every restart** instead of just once. This fixes that, and a related bug where enabling the watchtower server silently dropped emergency recovery entirely.

- **Clear the one-time `restore` flag.** The `restore` store flag set by the post-restore backup hook was never cleared, so the recovery oneshot and warning re-triggered on each restart. It's now cleared on disk early in `main` — before the reactive store `.const` watch — mirroring how `rescan` is handled, so recovery happens exactly once right after the restore. The session's local snapshot still drives the oneshot for that run.
- **Conditional daemons coexist in one chain.** `emergency-recover` and `watchtower-server` were each added inside separate `if` blocks that rebuilt from `baseDaemons`, so turning on the watchtower server clobbered the emergency-recover oneshot after a restore. Both are now added via thunks in a single daemon chain (returning `null` when not applicable), so they coexist.
- **Version bump** to `26.4.1:3` with release notes in all five locales, and rename `versions/v26.4.1.2.ts` → `versions/current.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
