### PR TITLE
chore: bump sling to 4.3.0; 26.6.1:0 → 26.6.1:1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN autoreconf -i && \
 # sling - download prebuilt binary
 FROM base AS sling
 ARG TARGETARCH
-ARG SLING_VERSION=v4.2.1
+ARG SLING_VERSION=v4.3.0
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* && \
     if [ "$TARGETARCH" = "amd64" ]; then SLING_ARCH=x86_64; else SLING_ARCH=aarch64; fi && \
     curl -fSL "https://github.com/daywalker90/sling/releases/download/${SLING_VERSION}/sling-${SLING_VERSION}-${SLING_ARCH}-linux-gnu.tar.gz" \

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,43 +4,13 @@ import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
 export const current = VersionInfo.of({
-  version: '26.6.1:0',
+  version: '26.6.1:1',
   releaseNotes: {
-    en_US: `**Bumps**
-
-- Core Lightning → 26.06.1 (fixes bwatch plugin registration failure)
-
-**Fixes**
-
-- gRPC is now reachable by other services on this server, fixing connections from apps like Alby Hub`,
-    es_ES: `**Actualizaciones**
-
-- Core Lightning → 26.06.1 (corrige el fallo de registro del plugin bwatch)
-
-**Correcciones**
-
-- gRPC ahora es accesible por otros servicios de este servidor, lo que corrige las conexiones desde aplicaciones como Alby Hub`,
-    de_DE: `**Aktualisierungen**
-
-- Core Lightning → 26.06.1 (behebt den Registrierungsfehler des bwatch-Plugins)
-
-**Fehlerbehebungen**
-
-- gRPC ist jetzt für andere Dienste auf diesem Server erreichbar, was Verbindungen von Apps wie Alby Hub behebt`,
-    pl_PL: `**Aktualizacje**
-
-- Core Lightning → 26.06.1 (naprawia błąd rejestracji wtyczki bwatch)
-
-**Poprawki**
-
-- gRPC jest teraz osiągalny przez inne usługi na tym serwerze, co naprawia połączenia z aplikacji takich jak Alby Hub`,
-    fr_FR: `**Mises à jour**
-
-- Core Lightning → 26.06.1 (corrige l’échec d’enregistrement du plugin bwatch)
-
-**Corrections**
-
-- gRPC est désormais accessible par les autres services de ce serveur, corrigeant les connexions depuis des applications comme Alby Hub`,
+    en_US: `Updated the Sling rebalancing plugin to 4.3.0: it now reads BLIP-18 inbound fees from the gossip store and accounts for them when rebalancing channels. Full notes: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    es_ES: `Se actualizó el complemento de reequilibrio Sling a 4.3.0: ahora lee las tarifas de entrada BLIP-18 del almacén de gossip y las tiene en cuenta al reequilibrar los canales. Notas completas: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    de_DE: `Das Sling-Rebalancing-Plugin wurde auf 4.3.0 aktualisiert: Es liest jetzt BLIP-18-Eingangsgebühren aus dem Gossip-Speicher und berücksichtigt sie beim Rebalancing der Kanäle. Vollständige Hinweise: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    pl_PL: `Zaktualizowano wtyczkę równoważenia Sling do wersji 4.3.0: odczytuje teraz opłaty przychodzące BLIP-18 z magazynu gossip i uwzględnia je podczas równoważenia kanałów. Pełne informacje: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    fr_FR: `Le plugin de rééquilibrage Sling a été mis à jour vers 4.3.0 : il lit désormais les frais entrants BLIP-18 depuis le magasin de gossip et en tient compte lors du rééquilibrage des canaux. Notes complètes : https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Monitor-cycle upstream check for **cln-startos** (`next`).

Core Lightning — the package's defining upstream — is unchanged at **v26.06.1**, so the StartOS revision increments rather than resetting: **26.6.1:0 → 26.6.1:1**.

The only auxiliary upstream that moved is the **Sling** rebalancing plugin:

- **Sling** `v4.2.1` → `v4.3.0` (`SLING_VERSION` ARG in `Dockerfile`)
  - Reads BLIP-18 inbound fees from the gossip store and accounts for them when rebalancing channels.
  - Bumps internal `cln-rpc`/`cln-plugin` to v0.7.
  - Full notes: https://github.com/daywalker90/sling/releases/tag/v4.3.0

## Unchanged upstreams (verified current)

| Source | Pin |
| --- | --- |
| lightningd (Core Lightning) | v26.06.1 (latest) |
| CLN Application (UI) | 26.04 (latest) |
| CLBOSS | v0.16.0 (latest) |
| TEOS (rust-teos) | ahead of latest release v0.2.0 |
| @start9labs/start-sdk | 1.5.3 (latest) |

No SDK bump (already current). `npm update` left the lockfile unchanged.

## Proposals (not implemented)

- The `plugins/` meta-submodule tracks `master` (no releases) and its upstream `master` has drifted (`b404933` → `c9db56f`). I left it pinned — pulling an untagged `master` move is unverifiable on the typecheck-only monitor cycle and risks the Docker build. Worth a deliberate refresh + full `make` in review if desired.
- `README.md` describes Sling as "Built from source", but it's actually consumed as a prebuilt release binary. Pre-existing; left untouched to keep this PR scoped.

## Verification

- `npm run check` (tsc --noEmit): green.
- Confirmed `sling-v4.3.0-{x86_64,aarch64}-linux-gnu.tar.gz` assets exist, matching the Dockerfile download URL pattern.
- Full `make` build deferred to PR review per monitor-cycle policy.