### PR TITLE
fix: serve clnrest over plain http so tor onions work; clnrest+http/https URL schemes for zeus

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Settings **not** managed by StartOS (hardcoded):
 | `bitcoin-rpcport`    | `8332`             | StartOS service networking |
 | `bitcoin-datadir`    | `/mnt/bitcoin`     | Mounted dependency volume  |
 | `clnrest-port`       | `3010`             | Fixed internal port        |
+| `clnrest-protocol`   | `http`             | Plain HTTP inside the container; Tor onions serve it directly (Tor already encrypts) and StartOS adds SSL for LAN/clearnet |
 | `grpc-port`          | `2106`             | Fixed internal port        |
 
 ## Default Overrides
@@ -120,7 +121,7 @@ applies.
 | RPC                      | 8080 | HTTP      | JSON-RPC commands                                                 |
 | Peer                     | 9735 | TCP (raw) | Lightning peer-to-peer connections                                |
 | gRPC                     | 2106 | HTTPS     | gRPC API (with TLS)                                               |
-| CLNrest                  | 3010 | HTTPS     | REST API with `clnrest://` URIs and embedded rune (when enabled)  |
+| CLNrest                  | 3010 | HTTP + HTTPS | REST API with `clnrest+http://` (Tor) / `clnrest+https://` (LAN) URIs and embedded rune (when enabled) |
 | Websocket (Clams)        | 7272 | HTTP      | Websocket for Clams Remote (when `ws::7272` bind-addr configured) |
 | TEOS Watchtower          | 9814 | TCP (raw) | Watchtower server (when enabled)                                  |
 

--- a/instructions.md
+++ b/instructions.md
@@ -28,7 +28,7 @@
 - **RPC** — JSON-RPC over HTTP for `lightning-cli` and scripts.
 - **Peer** — the Lightning peer-to-peer port; share this address with peers who want to open channels with you.
 - **grpc** — the gRPC API for apps and plugins that prefer typed RPC.
-- **CLNrest** — REST API. When enabled, the published URL contains the rune wallet apps need to authenticate; the scheme is `clnrest://`.
+- **CLNrest** — REST API. When enabled, the published URL contains the rune wallet apps need to authenticate. The scheme tells wallets like Zeus which protocol to use: `clnrest+http://` for plain-HTTP addresses (use this for Tor onion addresses — Tor already encrypts) and `clnrest+https://` for SSL addresses (LAN/clearnet).
 - **Clams Websocket** — websocket endpoint for Clams Remote, shown when the `clams-remote-websocket` option is on.
 - **TEOS Watchtower** — present only when the watchtower server is enabled.
 

--- a/startos/fileModels/config.ts
+++ b/startos/fileModels/config.ts
@@ -93,6 +93,9 @@ export const shape = z.object({
   rgb: iniString,
   'clnrest-host': iniString,
   'clnrest-port': iniNumber,
+  // Enforced to plaintext (CLN defaults to https) so the Tor onion path can
+  // serve plain HTTP; StartOS adds SSL for LAN/clearnet. See interfaces.ts.
+  'clnrest-protocol': z.literal('http').optional().catch('http'),
   'fee-base': iniNumber,
   'fee-per-satoshi': iniNumber,
   'min-capacity-sat': iniNumber,
@@ -311,8 +314,7 @@ export function fileToForm(
     raw: input ?? {},
     alias,
     color: rgb,
-    'tor-only':
-      alwaysUseProxy === undefined ? null : alwaysUseProxy === 'true',
+    'tor-only': alwaysUseProxy === undefined ? null : alwaysUseProxy === 'true',
     'clams-remote-websocket': bindAddr?.includes(`ws::${websocketPort}`),
     'fee-base': feeBase,
     'fee-rate': feePerSatoshi,
@@ -389,6 +391,7 @@ function formToFile(
     plugin: plugins.length > 0 ? plugins : undefined,
     'clnrest-host': clnrest ? '0.0.0.0' : undefined,
     'clnrest-port': clnrest ? clnrestPort : undefined,
+    'clnrest-protocol': clnrest ? 'http' : undefined,
   }
 }
 

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -115,14 +115,16 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
   // clnrest
   if (conf?.clnrest) {
     const clnrestMulti = sdk.MultiHost.of(effects, 'clnrest')
+    // clnrest is forced to plaintext (clnrest-protocol=http in the config) so
+    // that a plain-HTTP endpoint exists for Tor onion services — Tor already
+    // encrypts, and wallets like Zeus can't validate StartOS-issued certs.
+    // LAN/clearnet still gets HTTPS via the StartOS-terminated SSL listener.
     const clnrestMultiOrigin = await clnrestMulti.bindPort(clnrestPort, {
-      protocol: 'https',
+      protocol: 'http',
       preferredExternalPort: clnrestPort,
       addSsl: {
-        alpn: null,
         preferredExternalPort: clnrestPort,
         addXForwardedHeaders: false,
-        auth: null,
       },
     })
 
@@ -143,7 +145,10 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
         ),
         type: 'api',
         masked: false,
-        schemeOverride: { ssl: 'clnrest', noSsl: 'clnrest' },
+        // Zeus's clnrest parser reads the transport protocol from the scheme:
+        // clnrest+https:// / clnrest+http://. A bare clnrest:// is treated as
+        // https, so the http (Tor) URL must carry the +http marker.
+        schemeOverride: { ssl: 'clnrest+https', noSsl: 'clnrest+http' },
         username: null,
         path: '',
         query: { rune: rune ? rune : 'Error parsing Rune' },

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -82,12 +82,16 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
 
   // gRPC
   const grpcMulti = sdk.MultiHost.of(effects, 'grpc')
-  // cln-grpc terminates its own (mutual) TLS, so StartOS must pass the port
-  // through rather than add its own SSL layer (which would strip the client
-  // cert). protocol 'https' with no addSsl = passthrough.
+  // cln-grpc terminates its own mutual TLS, so StartOS must pass the port
+  // through untouched rather than terminate at the edge (which would present
+  // the device cert and strip the client cert). protocol/addSsl null +
+  // secure.ssl routes raw TCP / SNI passthrough; protocol 'https' does NOT —
+  // the SDK still synthesizes an addSsl config for it, terminating the TLS.
   const grpcMultiOrigin = await grpcMulti.bindPort(grpcPort, {
-    protocol: 'https',
+    protocol: null,
+    addSsl: null,
     preferredExternalPort: grpcPort,
+    secure: { ssl: true },
   })
   const grpc = sdk.createInterface(effects, {
     name: i18n('grpc'),

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -182,6 +182,9 @@ export const main = sdk.setupMain(async ({ effects }) => {
           LIGHTNING_VARS_FILE: `${rootDir}/.commando-env`,
           LIGHTNING_WS_PORT: String(wsPort),
           LIGHTNING_REST_PORT: String(clnrestPort),
+          // clnrest runs plaintext (clnrest-protocol=http); the app defaults
+          // this to https and would otherwise look for TLS certs.
+          LIGHTNING_REST_PROTOCOL: 'http',
           LIGHTNING_GRPC_PORT: String(grpcPort),
         },
       },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -10,27 +10,32 @@ export const current = VersionInfo.of({
 
 - CLNrest is reachable again: the previous release's certificate change broke all CLNrest connections through StartOS (LAN and Tor)
 - CLNrest now serves plain HTTP, so Tor onion services can expose it without TLS — restoring Zeus-over-Tor connections. LAN/clearnet access remains HTTPS via StartOS
-- CLNrest URLs now use the \`clnrest+http://\` / \`clnrest+https://\` schemes so wallets like Zeus connect with the correct protocol`,
+- CLNrest URLs now use the \`clnrest+http://\` / \`clnrest+https://\` schemes so wallets like Zeus connect with the correct protocol
+- gRPC now passes through StartOS untouched so cln-grpc's native mutual-TLS certificate is used end-to-end, fixing gRPC connections from apps like Alby Hub`,
     es_ES: `**Correcciones**
 
 - CLNrest vuelve a ser accesible: el cambio de certificados de la versión anterior rompió todas las conexiones CLNrest a través de StartOS (LAN y Tor)
 - CLNrest ahora sirve HTTP plano, de modo que los servicios onion de Tor pueden exponerlo sin TLS — restaurando las conexiones de Zeus por Tor. El acceso LAN/clearnet sigue siendo HTTPS a través de StartOS
-- Las URL de CLNrest ahora usan los esquemas \`clnrest+http://\` / \`clnrest+https://\` para que carteras como Zeus se conecten con el protocolo correcto`,
+- Las URL de CLNrest ahora usan los esquemas \`clnrest+http://\` / \`clnrest+https://\` para que carteras como Zeus se conecten con el protocolo correcto
+- gRPC ahora pasa a través de StartOS sin modificaciones, de modo que el certificado TLS mutuo nativo de cln-grpc se usa de extremo a extremo, corrigiendo las conexiones gRPC desde aplicaciones como Alby Hub`,
     de_DE: `**Fehlerbehebungen**
 
 - CLNrest ist wieder erreichbar: die Zertifikatsänderung der vorherigen Version hat alle CLNrest-Verbindungen über StartOS unterbrochen (LAN und Tor)
 - CLNrest liefert jetzt einfaches HTTP, sodass Tor-Onion-Dienste es ohne TLS bereitstellen können — Zeus-über-Tor-Verbindungen funktionieren wieder. LAN-/Clearnet-Zugriff bleibt HTTPS über StartOS
-- CLNrest-URLs verwenden jetzt die Schemata \`clnrest+http://\` / \`clnrest+https://\`, damit Wallets wie Zeus sich mit dem richtigen Protokoll verbinden`,
+- CLNrest-URLs verwenden jetzt die Schemata \`clnrest+http://\` / \`clnrest+https://\`, damit Wallets wie Zeus sich mit dem richtigen Protokoll verbinden
+- gRPC wird jetzt unverändert durch StartOS durchgereicht, sodass das native gegenseitige TLS-Zertifikat von cln-grpc durchgängig verwendet wird — das behebt gRPC-Verbindungen von Apps wie Alby Hub`,
     pl_PL: `**Poprawki**
 
 - CLNrest jest znów osiągalny: zmiana certyfikatów w poprzednim wydaniu zepsuła wszystkie połączenia CLNrest przez StartOS (LAN i Tor)
 - CLNrest serwuje teraz czysty HTTP, dzięki czemu usługi onion Tora mogą go udostępniać bez TLS — przywracając połączenia Zeus przez Tor. Dostęp LAN/clearnet pozostaje HTTPS przez StartOS
-- Adresy URL CLNrest używają teraz schematów \`clnrest+http://\` / \`clnrest+https://\`, dzięki czemu portfele takie jak Zeus łączą się właściwym protokołem`,
+- Adresy URL CLNrest używają teraz schematów \`clnrest+http://\` / \`clnrest+https://\`, dzięki czemu portfele takie jak Zeus łączą się właściwym protokołem
+- gRPC jest teraz przekazywane przez StartOS bez zmian, dzięki czemu natywny wzajemny certyfikat TLS cln-grpc jest używany od końca do końca, co naprawia połączenia gRPC z aplikacji takich jak Alby Hub`,
     fr_FR: `**Corrections**
 
 - CLNrest est de nouveau accessible : le changement de certificats de la version précédente avait cassé toutes les connexions CLNrest via StartOS (LAN et Tor)
 - CLNrest sert désormais du HTTP en clair, afin que les services onion Tor puissent l'exposer sans TLS — rétablissant les connexions Zeus via Tor. L'accès LAN/clearnet reste en HTTPS via StartOS
-- Les URL CLNrest utilisent désormais les schémas \`clnrest+http://\` / \`clnrest+https://\` pour que les portefeuilles comme Zeus se connectent avec le bon protocole`,
+- Les URL CLNrest utilisent désormais les schémas \`clnrest+http://\` / \`clnrest+https://\` pour que les portefeuilles comme Zeus se connectent avec le bon protocole
+- gRPC est désormais transmis par StartOS sans modification, afin que le certificat TLS mutuel natif de cln-grpc soit utilisé de bout en bout — corrigeant les connexions gRPC depuis des applications comme Alby Hub`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,43 +4,33 @@ import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
 export const current = VersionInfo.of({
-  version: '26.6.1:0',
+  version: '26.6.1:1',
   releaseNotes: {
-    en_US: `**Bumps**
+    en_US: `**Fixes**
 
-- Core Lightning → 26.06.1 (fixes bwatch plugin registration failure)
+- CLNrest is reachable again: the previous release's certificate change broke all CLNrest connections through StartOS (LAN and Tor)
+- CLNrest now serves plain HTTP, so Tor onion services can expose it without TLS — restoring Zeus-over-Tor connections. LAN/clearnet access remains HTTPS via StartOS
+- CLNrest URLs now use the \`clnrest+http://\` / \`clnrest+https://\` schemes so wallets like Zeus connect with the correct protocol`,
+    es_ES: `**Correcciones**
 
-**Fixes**
+- CLNrest vuelve a ser accesible: el cambio de certificados de la versión anterior rompió todas las conexiones CLNrest a través de StartOS (LAN y Tor)
+- CLNrest ahora sirve HTTP plano, de modo que los servicios onion de Tor pueden exponerlo sin TLS — restaurando las conexiones de Zeus por Tor. El acceso LAN/clearnet sigue siendo HTTPS a través de StartOS
+- Las URL de CLNrest ahora usan los esquemas \`clnrest+http://\` / \`clnrest+https://\` para que carteras como Zeus se conecten con el protocolo correcto`,
+    de_DE: `**Fehlerbehebungen**
 
-- gRPC is now reachable by other services on this server, fixing connections from apps like Alby Hub`,
-    es_ES: `**Actualizaciones**
+- CLNrest ist wieder erreichbar: die Zertifikatsänderung der vorherigen Version hat alle CLNrest-Verbindungen über StartOS unterbrochen (LAN und Tor)
+- CLNrest liefert jetzt einfaches HTTP, sodass Tor-Onion-Dienste es ohne TLS bereitstellen können — Zeus-über-Tor-Verbindungen funktionieren wieder. LAN-/Clearnet-Zugriff bleibt HTTPS über StartOS
+- CLNrest-URLs verwenden jetzt die Schemata \`clnrest+http://\` / \`clnrest+https://\`, damit Wallets wie Zeus sich mit dem richtigen Protokoll verbinden`,
+    pl_PL: `**Poprawki**
 
-- Core Lightning → 26.06.1 (corrige el fallo de registro del plugin bwatch)
+- CLNrest jest znów osiągalny: zmiana certyfikatów w poprzednim wydaniu zepsuła wszystkie połączenia CLNrest przez StartOS (LAN i Tor)
+- CLNrest serwuje teraz czysty HTTP, dzięki czemu usługi onion Tora mogą go udostępniać bez TLS — przywracając połączenia Zeus przez Tor. Dostęp LAN/clearnet pozostaje HTTPS przez StartOS
+- Adresy URL CLNrest używają teraz schematów \`clnrest+http://\` / \`clnrest+https://\`, dzięki czemu portfele takie jak Zeus łączą się właściwym protokołem`,
+    fr_FR: `**Corrections**
 
-**Correcciones**
-
-- gRPC ahora es accesible por otros servicios de este servidor, lo que corrige las conexiones desde aplicaciones como Alby Hub`,
-    de_DE: `**Aktualisierungen**
-
-- Core Lightning → 26.06.1 (behebt den Registrierungsfehler des bwatch-Plugins)
-
-**Fehlerbehebungen**
-
-- gRPC ist jetzt für andere Dienste auf diesem Server erreichbar, was Verbindungen von Apps wie Alby Hub behebt`,
-    pl_PL: `**Aktualizacje**
-
-- Core Lightning → 26.06.1 (naprawia błąd rejestracji wtyczki bwatch)
-
-**Poprawki**
-
-- gRPC jest teraz osiągalny przez inne usługi na tym serwerze, co naprawia połączenia z aplikacji takich jak Alby Hub`,
-    fr_FR: `**Mises à jour**
-
-- Core Lightning → 26.06.1 (corrige l’échec d’enregistrement du plugin bwatch)
-
-**Corrections**
-
-- gRPC est désormais accessible par les autres services de ce serveur, corrigeant les connexions depuis des applications comme Alby Hub`,
+- CLNrest est de nouveau accessible : le changement de certificats de la version précédente avait cassé toutes les connexions CLNrest via StartOS (LAN et Tor)
+- CLNrest sert désormais du HTTP en clair, afin que les services onion Tor puissent l'exposer sans TLS — rétablissant les connexions Zeus via Tor. L'accès LAN/clearnet reste en HTTPS via StartOS
+- Les URL CLNrest utilisent désormais les schémas \`clnrest+http://\` / \`clnrest+https://\` pour que les portefeuilles comme Zeus se connectent avec le bon protocole`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

**The bug (verified live on a 26.6.1:0 box):** the 26.6.1:0 migration deleted `ca.pem`/`server.pem`/`client.pem` from the network dir to fix gRPC — but clnrest shares those exact files (`clnrest-certs` defaults to the network dir). clnrest regenerated CLN-native certs (`CN=cln grpc Server`, issuer `CN=cln Root CA`) that the StartOS SSL proxy cannot verify against the device root CA, so the proxy aborts every clnrest connection mid-handshake. Since the `https` + `addSsl` binding exposes *only* the proxy (no raw port), clnrest has been completely unreachable — LAN and Tor — since 26.6.1:0. gRPC survived because the same release made it passthrough.

Independent of that regression, the `https` binding marks clnrest `secure: { ssl: true }`, which makes the Tor package refuse to create non-SSL onion services — so there was no plain-HTTP-over-Tor path for Zeus at all.

**The fix:**
- Force `clnrest-protocol=http` (enforced via the config file model, written on init by the existing `seedFiles` merge) and bind with `protocol: 'http'` + `addSsl`. Tor onion services can now expose the plaintext endpoint directly (Tor already encrypts), and StartOS terminates SSL for LAN/clearnet over the plaintext backend — which also repairs the broken proxy path, including existing SSL onions.
- `schemeOverride` becomes `clnrest+https` / `clnrest+http`. Zeus parses the transport protocol from the scheme (`clnrest+<protocol>://`); a bare `clnrest://` is treated as https, so the Tor URL must carry `+http`.
- `LIGHTNING_REST_PROTOCOL=http` for the cln-application UI, which defaults to https and would otherwise look for TLS certs.

Existing installs keep their SSL listener on external port 3010 (assigned ports are sticky); the new raw HTTP listener gets an allocated port, while non-SSL onions always use 3010. Fresh installs get HTTP on 3010.

**Note:** lnd-startos uses the identical `https` + `addSsl` pattern in front of LND's self-signed REST/gRPC TLS and likely has the same dead-proxy + no-http-onion problem — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)