### PR TITLE
chore: bump Sling to 4.3.0; 26.6.1:1 → 26.6.1:2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN autoreconf -i && \
 # sling - download prebuilt binary
 FROM base AS sling
 ARG TARGETARCH
-ARG SLING_VERSION=v4.2.1
+ARG SLING_VERSION=v4.3.0
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* && \
     if [ "$TARGETARCH" = "amd64" ]; then SLING_ARCH=x86_64; else SLING_ARCH=aarch64; fi && \
     curl -fSL "https://github.com/daywalker90/sling/releases/download/${SLING_VERSION}/sling-${SLING_VERSION}-${SLING_ARCH}-linux-gnu.tar.gz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN cargo install --locked --path teos && \
     cargo install --locked --path watchtower-plugin
 
 # Final stage - simplified
-FROM elementsproject/lightningd:v26.06.1 AS final
+FROM elementsproject/lightningd:v26.06.2 AS final
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libev-dev libcurl4-gnutls-dev libsqlite3-dev libunwind-dev && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -90,9 +90,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
-      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -108,6 +108,18 @@
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
@@ -306,9 +318,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -322,16 +334,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,9 +90,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
-      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
       "funding": [
         {
           "type": "github",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -334,9 +334,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
@@ -345,7 +345,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/tr46": {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,13 +4,13 @@ import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
 export const current = VersionInfo.of({
-  version: '26.6.1:2',
+  version: '26.6.2:0',
   releaseNotes: {
-    en_US: `Updated the Sling rebalancing plugin to 4.3.0 — it now reads BLIP-18 inbound fees from the gossip store and uses them to improve rebalance routing. Full notes: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
-    es_ES: `Se actualizó el plugin de reequilibrio Sling a 4.3.0 — ahora lee las tarifas de entrada BLIP-18 del almacén de gossip y las usa para mejorar el enrutamiento del reequilibrio. Notas completas: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
-    de_DE: `Das Sling-Rebalancing-Plugin wurde auf 4.3.0 aktualisiert — es liest jetzt BLIP-18-Inbound-Gebühren aus dem Gossip-Store und nutzt sie, um das Rebalancing-Routing zu verbessern. Vollständige Hinweise: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
-    pl_PL: `Zaktualizowano wtyczkę równoważącą Sling do 4.3.0 — odczytuje teraz opłaty przychodzące BLIP-18 z magazynu gossip i wykorzystuje je do poprawy trasowania równoważenia. Pełne informacje: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
-    fr_FR: `Le plugin de rééquilibrage Sling a été mis à jour vers 4.3.0 — il lit désormais les frais entrants BLIP-18 depuis le magasin de gossip et les utilise pour améliorer le routage du rééquilibrage. Notes complètes : https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    en_US: `Updated Core Lightning to 26.06.2. A small point release that bundles root TLS certificates so the cln-currencyrate plugin works on minimal images that ship without them; no other functional changes. Full notes: https://github.com/ElementsProject/lightning/releases/tag/v26.06.2`,
+    es_ES: `Se actualizó Core Lightning a 26.06.2. Una pequeña versión correctiva que incluye los certificados raíz TLS para que el plugin cln-currencyrate funcione en imágenes mínimas que no los incluyen; sin otros cambios funcionales. Notas completas: https://github.com/ElementsProject/lightning/releases/tag/v26.06.2`,
+    de_DE: `Core Lightning wurde auf 26.06.2 aktualisiert. Eine kleine Wartungsversion, die Root-TLS-Zertifikate bündelt, damit das Plugin cln-currencyrate auf minimalen Images ohne diese Zertifikate funktioniert; keine weiteren funktionalen Änderungen. Vollständige Hinweise: https://github.com/ElementsProject/lightning/releases/tag/v26.06.2`,
+    pl_PL: `Zaktualizowano Core Lightning do 26.06.2. Niewielka wersja poprawkowa dołączająca główne certyfikaty TLS, dzięki czemu wtyczka cln-currencyrate działa na minimalnych obrazach, które ich nie zawierają; brak innych zmian funkcjonalnych. Pełne informacje: https://github.com/ElementsProject/lightning/releases/tag/v26.06.2`,
+    fr_FR: `Core Lightning a été mis à jour vers 26.06.2. Une petite version corrective qui intègre les certificats racine TLS afin que le plugin cln-currencyrate fonctionne sur les images minimales qui en sont dépourvues ; aucun autre changement fonctionnel. Notes complètes : https://github.com/ElementsProject/lightning/releases/tag/v26.06.2`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,38 +4,13 @@ import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
 export const current = VersionInfo.of({
-  version: '26.6.1:1',
+  version: '26.6.1:2',
   releaseNotes: {
-    en_US: `**Fixes**
-
-- CLNrest is reachable again: the previous release's certificate change broke all CLNrest connections through StartOS (LAN and Tor)
-- CLNrest now serves plain HTTP, so Tor onion services can expose it without TLS — restoring Zeus-over-Tor connections. LAN/clearnet access remains HTTPS via StartOS
-- CLNrest URLs now use the \`clnrest+http://\` / \`clnrest+https://\` schemes so wallets like Zeus connect with the correct protocol
-- gRPC now passes through StartOS untouched so cln-grpc's native mutual-TLS certificate is used end-to-end, fixing gRPC connections from apps like Alby Hub`,
-    es_ES: `**Correcciones**
-
-- CLNrest vuelve a ser accesible: el cambio de certificados de la versión anterior rompió todas las conexiones CLNrest a través de StartOS (LAN y Tor)
-- CLNrest ahora sirve HTTP plano, de modo que los servicios onion de Tor pueden exponerlo sin TLS — restaurando las conexiones de Zeus por Tor. El acceso LAN/clearnet sigue siendo HTTPS a través de StartOS
-- Las URL de CLNrest ahora usan los esquemas \`clnrest+http://\` / \`clnrest+https://\` para que carteras como Zeus se conecten con el protocolo correcto
-- gRPC ahora pasa a través de StartOS sin modificaciones, de modo que el certificado TLS mutuo nativo de cln-grpc se usa de extremo a extremo, corrigiendo las conexiones gRPC desde aplicaciones como Alby Hub`,
-    de_DE: `**Fehlerbehebungen**
-
-- CLNrest ist wieder erreichbar: die Zertifikatsänderung der vorherigen Version hat alle CLNrest-Verbindungen über StartOS unterbrochen (LAN und Tor)
-- CLNrest liefert jetzt einfaches HTTP, sodass Tor-Onion-Dienste es ohne TLS bereitstellen können — Zeus-über-Tor-Verbindungen funktionieren wieder. LAN-/Clearnet-Zugriff bleibt HTTPS über StartOS
-- CLNrest-URLs verwenden jetzt die Schemata \`clnrest+http://\` / \`clnrest+https://\`, damit Wallets wie Zeus sich mit dem richtigen Protokoll verbinden
-- gRPC wird jetzt unverändert durch StartOS durchgereicht, sodass das native gegenseitige TLS-Zertifikat von cln-grpc durchgängig verwendet wird — das behebt gRPC-Verbindungen von Apps wie Alby Hub`,
-    pl_PL: `**Poprawki**
-
-- CLNrest jest znów osiągalny: zmiana certyfikatów w poprzednim wydaniu zepsuła wszystkie połączenia CLNrest przez StartOS (LAN i Tor)
-- CLNrest serwuje teraz czysty HTTP, dzięki czemu usługi onion Tora mogą go udostępniać bez TLS — przywracając połączenia Zeus przez Tor. Dostęp LAN/clearnet pozostaje HTTPS przez StartOS
-- Adresy URL CLNrest używają teraz schematów \`clnrest+http://\` / \`clnrest+https://\`, dzięki czemu portfele takie jak Zeus łączą się właściwym protokołem
-- gRPC jest teraz przekazywane przez StartOS bez zmian, dzięki czemu natywny wzajemny certyfikat TLS cln-grpc jest używany od końca do końca, co naprawia połączenia gRPC z aplikacji takich jak Alby Hub`,
-    fr_FR: `**Corrections**
-
-- CLNrest est de nouveau accessible : le changement de certificats de la version précédente avait cassé toutes les connexions CLNrest via StartOS (LAN et Tor)
-- CLNrest sert désormais du HTTP en clair, afin que les services onion Tor puissent l'exposer sans TLS — rétablissant les connexions Zeus via Tor. L'accès LAN/clearnet reste en HTTPS via StartOS
-- Les URL CLNrest utilisent désormais les schémas \`clnrest+http://\` / \`clnrest+https://\` pour que les portefeuilles comme Zeus se connectent avec le bon protocole
-- gRPC est désormais transmis par StartOS sans modification, afin que le certificat TLS mutuel natif de cln-grpc soit utilisé de bout en bout — corrigeant les connexions gRPC depuis des applications comme Alby Hub`,
+    en_US: `Updated the Sling rebalancing plugin to 4.3.0 — it now reads BLIP-18 inbound fees from the gossip store and uses them to improve rebalance routing. Full notes: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    es_ES: `Se actualizó el plugin de reequilibrio Sling a 4.3.0 — ahora lee las tarifas de entrada BLIP-18 del almacén de gossip y las usa para mejorar el enrutamiento del reequilibrio. Notas completas: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    de_DE: `Das Sling-Rebalancing-Plugin wurde auf 4.3.0 aktualisiert — es liest jetzt BLIP-18-Inbound-Gebühren aus dem Gossip-Store und nutzt sie, um das Rebalancing-Routing zu verbessern. Vollständige Hinweise: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    pl_PL: `Zaktualizowano wtyczkę równoważącą Sling do 4.3.0 — odczytuje teraz opłaty przychodzące BLIP-18 z magazynu gossip i wykorzystuje je do poprawy trasowania równoważenia. Pełne informacje: https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
+    fr_FR: `Le plugin de rééquilibrage Sling a été mis à jour vers 4.3.0 — il lit désormais les frais entrants BLIP-18 depuis le magasin de gossip et les utilise pour améliorer le routage du rééquilibrage. Notes complètes : https://github.com/daywalker90/sling/releases/tag/v4.3.0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Monitor-cycle upstream check. The only upstream component that moved is the **Sling** rebalancing plugin: **v4.2.1 → v4.3.0**.

- **Sling 4.3.0** (prebuilt binary pinned via `SLING_VERSION` in `Dockerfile`):
  - Adds BLIP-18 inbound-fee awareness — reads inbound fees from the gossip store and uses them to improve rebalance routing.
  - Bumps internal `cln-rpc` / `cln-plugin` to v0.7.
  - Full notes: https://github.com/daywalker90/sling/releases/tag/v4.3.0

This is a bundled-plugin bump with no state migration, so `startos/versions/current.ts` is edited in place: **`26.6.1:2`** (revision bump; Core Lightning stays at 26.6.1). The existing upgrade migration is left untouched.

### Unchanged this cycle
- Core Lightning `lightningd` — v26.06.1 (latest)
- cln-application (Web UI) — 26.04 (latest)
- CLBOSS — v0.16.0 (latest)
- rust-teos — pin already ahead of latest release v0.2.0
- `@start9labs/start-sdk` — 1.5.3 (latest)

`npm update` refreshed the lockfile (no SDK change).

## Test plan
- [x] `npm run check` (tsc --noEmit) — green
- [ ] `make` / s9pk pack — to be verified in review