### PR TITLE
fix: report real getinfo error in check-synced; idempotent grpc cert-reset (26.6.1:2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,6 @@
 # TODO
+
+- Once **0.4.0 is out of beta**, delete the gRPC cert-reset block from the `up`
+  migration in `startos/versions/current.ts`. It only clears the stale
+  `c-lightning.startos` certs written by the beta-era `setupCerts` init
+  (0.4.0-beta `25.12.1:x … 26.6:0`); by GA no install still carries them.

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -208,15 +208,35 @@ export const main = sdk.setupMain(async ({ effects }) => {
             'getinfo',
           ])
 
+          // Check the exit code before parsing: when lightningd's RPC is not
+          // answering, lightning-cli exits non-zero with empty stdout, and
+          // JSON.parse('') would fail the check with the unhelpful
+          // "Unexpected end of JSON input" instead of the real error.
+          if (getinfoRes.exitCode !== 0) {
+            return {
+              result: 'failure',
+              message: `Error calling 'lightning-cli getinfo': ${getinfoRes.stderr}`,
+            }
+          }
+
+          let getinfo: {
+            warning_lightningd_sync?: string
+            warning_bitcoind_sync?: string
+            blockheight: number
+          }
+          try {
+            getinfo = JSON.parse(getinfoRes.stdout as string)
+          } catch {
+            return {
+              result: 'failure',
+              message: `'lightning-cli getinfo' returned unparseable output: ${getinfoRes.stdout}`,
+            }
+          }
           const {
             warning_lightningd_sync,
             warning_bitcoind_sync,
             blockheight,
-          }: {
-            warning_lightningd_sync?: string
-            warning_bitcoind_sync?: string
-            blockheight: number
-          } = JSON.parse(getinfoRes.stdout as string)
+          } = getinfo
 
           if (warning_bitcoind_sync) {
             return {
@@ -244,18 +264,11 @@ export const main = sdk.setupMain(async ({ effects }) => {
             }
           }
 
-          if (getinfoRes.exitCode === 0) {
-            return {
-              result: 'success',
-              message: i18n(
-                'Synced to chain and ready to perform on-chain operations',
-              ),
-            }
-          }
-
           return {
-            result: 'failure',
-            message: `Error calling 'lightning-cli getinfo': ${getinfoRes.stderr}`,
+            result: 'success',
+            message: i18n(
+              'Synced to chain and ready to perform on-chain operations',
+            ),
           }
         },
       },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,58 +1,72 @@
 import { IMPOSSIBLE, VersionInfo, YAML } from '@start9labs/start-sdk'
 import { readFile, rm } from 'fs/promises'
+import { X509Certificate } from 'crypto'
 import { clnConfig } from '../fileModels/config'
 import { storeJson } from '../fileModels/store.json'
 
 export const current = VersionInfo.of({
-  version: '26.6.1:1',
+  version: '26.6.1:2',
   releaseNotes: {
     en_US: `**Fixes**
 
-- CLNrest is reachable again: the previous release's certificate change broke all CLNrest connections through StartOS (LAN and Tor)
-- CLNrest now serves plain HTTP, so Tor onion services can expose it without TLS — restoring Zeus-over-Tor connections. LAN/clearnet access remains HTTPS via StartOS
-- CLNrest URLs now use the \`clnrest+http://\` / \`clnrest+https://\` schemes so wallets like Zeus connect with the correct protocol
-- gRPC now passes through StartOS untouched so cln-grpc's native mutual-TLS certificate is used end-to-end, fixing gRPC connections from apps like Alby Hub`,
+- The Synced health check now reports the real error from lightningd when \`getinfo\` fails, instead of failing with "Unexpected end of JSON input"`,
     es_ES: `**Correcciones**
 
-- CLNrest vuelve a ser accesible: el cambio de certificados de la versión anterior rompió todas las conexiones CLNrest a través de StartOS (LAN y Tor)
-- CLNrest ahora sirve HTTP plano, de modo que los servicios onion de Tor pueden exponerlo sin TLS — restaurando las conexiones de Zeus por Tor. El acceso LAN/clearnet sigue siendo HTTPS a través de StartOS
-- Las URL de CLNrest ahora usan los esquemas \`clnrest+http://\` / \`clnrest+https://\` para que carteras como Zeus se conecten con el protocolo correcto
-- gRPC ahora pasa a través de StartOS sin modificaciones, de modo que el certificado TLS mutuo nativo de cln-grpc se usa de extremo a extremo, corrigiendo las conexiones gRPC desde aplicaciones como Alby Hub`,
+- La comprobación de salud «Synced» ahora informa del error real de lightningd cuando \`getinfo\` falla, en lugar de fallar con «Unexpected end of JSON input»`,
     de_DE: `**Fehlerbehebungen**
 
-- CLNrest ist wieder erreichbar: die Zertifikatsänderung der vorherigen Version hat alle CLNrest-Verbindungen über StartOS unterbrochen (LAN und Tor)
-- CLNrest liefert jetzt einfaches HTTP, sodass Tor-Onion-Dienste es ohne TLS bereitstellen können — Zeus-über-Tor-Verbindungen funktionieren wieder. LAN-/Clearnet-Zugriff bleibt HTTPS über StartOS
-- CLNrest-URLs verwenden jetzt die Schemata \`clnrest+http://\` / \`clnrest+https://\`, damit Wallets wie Zeus sich mit dem richtigen Protokoll verbinden
-- gRPC wird jetzt unverändert durch StartOS durchgereicht, sodass das native gegenseitige TLS-Zertifikat von cln-grpc durchgängig verwendet wird — das behebt gRPC-Verbindungen von Apps wie Alby Hub`,
+- Die Gesundheitsprüfung „Synced" meldet jetzt den tatsächlichen Fehler von lightningd, wenn \`getinfo\` fehlschlägt, statt mit „Unexpected end of JSON input" zu scheitern`,
     pl_PL: `**Poprawki**
 
-- CLNrest jest znów osiągalny: zmiana certyfikatów w poprzednim wydaniu zepsuła wszystkie połączenia CLNrest przez StartOS (LAN i Tor)
-- CLNrest serwuje teraz czysty HTTP, dzięki czemu usługi onion Tora mogą go udostępniać bez TLS — przywracając połączenia Zeus przez Tor. Dostęp LAN/clearnet pozostaje HTTPS przez StartOS
-- Adresy URL CLNrest używają teraz schematów \`clnrest+http://\` / \`clnrest+https://\`, dzięki czemu portfele takie jak Zeus łączą się właściwym protokołem
-- gRPC jest teraz przekazywane przez StartOS bez zmian, dzięki czemu natywny wzajemny certyfikat TLS cln-grpc jest używany od końca do końca, co naprawia połączenia gRPC z aplikacji takich jak Alby Hub`,
+- Kontrola stanu „Synced" zgłasza teraz rzeczywisty błąd lightningd, gdy \`getinfo\` się nie powiedzie, zamiast kończyć się błędem „Unexpected end of JSON input"`,
     fr_FR: `**Corrections**
 
-- CLNrest est de nouveau accessible : le changement de certificats de la version précédente avait cassé toutes les connexions CLNrest via StartOS (LAN et Tor)
-- CLNrest sert désormais du HTTP en clair, afin que les services onion Tor puissent l'exposer sans TLS — rétablissant les connexions Zeus via Tor. L'accès LAN/clearnet reste en HTTPS via StartOS
-- Les URL CLNrest utilisent désormais les schémas \`clnrest+http://\` / \`clnrest+https://\` pour que les portefeuilles comme Zeus se connectent avec le bon protocole
-- gRPC est désormais transmis par StartOS sans modification, afin que le certificat TLS mutuel natif de cln-grpc soit utilisé de bout en bout — corrigeant les connexions gRPC depuis des applications comme Alby Hub`,
+- Le contrôle de santé « Synced » signale désormais l'erreur réelle de lightningd lorsque \`getinfo\` échoue, au lieu d'échouer avec « Unexpected end of JSON input »`,
   },
   migrations: {
     up: async ({ effects }) => {
-      // Remove the legacy StartOS-issued gRPC certs (older versions wrote certs
-      // for c-lightning.startos here) so cln-grpc regenerates its native "cln"
-      // certs, which is the TLS identity gRPC clients like Alby Hub expect.
+      // Reset the legacy StartOS-issued gRPC certs so cln-grpc regenerates its
+      // native "cln" certs — the TLS identity clients like Alby Hub expect. The
+      // since-removed setupCerts init (0.4.0-beta releases 25.12.1:x … 26.6:0)
+      // overwrote cln-grpc's certs with StartOS-issued ones bearing a
+      // `c-lightning.startos` SAN; we key on that SAN so the reset is idempotent
+      // and safe to run on every update — native certs (already-fixed installs,
+      // and installs predating setupCerts such as 0.3.5.1) are left untouched, so
+      // it never deletes a live identity or breaks an existing pairing.
+      //
+      // TODO: delete this block once 0.4.0 is out of beta. The only installs that
+      // carry these certs are from the beta setupCerts era; by GA they will all
+      // have migrated through a reset and the SAN guard will match nothing.
       const grpcCertDir = '/media/startos/volumes/main/bitcoin'
-      await Promise.all(
-        [
-          'ca.pem',
-          'ca-key.pem',
-          'server.pem',
-          'server-key.pem',
-          'client.pem',
-          'client-key.pem',
-        ].map((file) => rm(`${grpcCertDir}/${file}`, { force: true })),
-      )
+      const serverCert = await readFile(
+        `${grpcCertDir}/server.pem`,
+        'utf-8',
+      ).catch(() => null)
+      const certBlocks =
+        serverCert?.match(
+          /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g,
+        ) ?? []
+      const startOsIssued = certBlocks.some((pem) => {
+        try {
+          return !!new X509Certificate(pem).subjectAltName?.includes(
+            'c-lightning.startos',
+          )
+        } catch {
+          return false
+        }
+      })
+      if (startOsIssued) {
+        await Promise.all(
+          [
+            'ca.pem',
+            'ca-key.pem',
+            'server.pem',
+            'server-key.pem',
+            'client.pem',
+            'client-key.pem',
+          ].map((file) => rm(`${grpcCertDir}/${file}`, { force: true })),
+        )
+      }
 
       // get old config.yaml
       const configYaml:


### PR DESCRIPTION
Supersedes #174 (from a fork; same `check-synced` fix but a different, heavier take on the migration — see below).

## `check-synced` health check

`check-synced` called `JSON.parse(getinfoRes.stdout)` **before** checking the exit code. When `lightning-cli getinfo` fails (RPC not answering, exec failure) stdout is empty, so `JSON.parse('')` throws `SyntaxError: Unexpected end of JSON input`, which the health runner surfaces verbatim — and the stderr-bearing failure branch below it was unreachable in exactly that case.

Fix: check `exitCode !== 0` first and return the real stderr; wrap the parse in try/catch; drop the now-dead trailing `exitCode === 0` guard.

## Migration: idempotent gRPC cert reset (`26.6.1:1 → 26.6.1:2`)

The `26.6.1:0` migration unconditionally deletes the cln-grpc certs so the plugin regenerates its native `cln` identity. Run again on a later update, it deletes the *regenerated* certs — minting a new CA and breaking existing gRPC pairings (e.g. Alby Hub).

Rather than restructure the version graph to stop it re-running, this makes the reset **idempotent**: it only deletes certs carrying the legacy `c-lightning.startos` SAN (what the since-removed `setupCerts` init wrote). That's safe to run on every update, so `current.ts` bumps **in place** — no version-file split.

Why key on the SAN and not "coming from 0.3.5.1": the stale certs are an artifact of `setupCerts`, which ran on 0.4.x releases `25.12.1:x … 26.6:0` — installs that have **no** old `config.yaml`. 0.3.5.1 installs, by contrast, ran cln-grpc with its **native** certs (the old package has no cert-provisioning code) and must be **left alone**:

| Source | `bitcoin/*.pem` | reset? |
|---|---|---|
| 0.3.5.1 | native `cln` | **no** — a reset would break their pairing |
| `25.12.1:x … 26.6:0` (setupCerts era) | stale `c-lightning.startos` | **yes** |
| already-fixed (`26.6.1:0/1`) | native `cln` | **no** |

The SAN guard is correct for all three; a `configYaml` gate would get the first two exactly backwards (reset 0.3.5.1's good certs, skip the setupCerts-era's stale ones).

Because the guard scopes the reset by cert *identity*, it needs no version-graph scoping or separate migration file — it lives in `current.ts`. But it only matters for the 0.4.0-beta `setupCerts` era, so it carries a code `TODO` and a `TODO.md` entry to delete it once 0.4.0 leaves beta (by GA nothing still carries those certs).

## Verification
- `npm run check` (tsc, SDK 1.5.3) and prettier clean; `npm run build` (ncc) bundles the `crypto` import.
- Discriminator exercised against real certs: a `c-lightning.startos` chain → reset; a `CN=cln` cert, a missing file, and garbage → left untouched.

## Test plan
- [ ] Install a `26.6:0`-era build (setupCerts wrote `c-lightning.startos` certs), pair a gRPC client (e.g. Alby Hub), then update to `26.6.1:2`: after re-pairing against the regenerated native cert, gRPC reconnects; `bitcoin/server.pem` is now the `cln` identity.
- [ ] From `26.6.1:1 → 26.6.1:2`: `bitcoin/*.pem` are **unchanged** (same CA/serial) and an existing Alby Hub pairing keeps working with **no** re-pair.
- [ ] Stop lightningd (or otherwise make RPC unavailable) and observe the **Synced** check: it now shows `Error calling 'lightning-cli getinfo': …` (real stderr), not "Unexpected end of JSON input".
- [ ] Fresh install of `26.6.1:2`: installs and syncs normally (migration does not run on fresh installs).
