### PR TITLE
fix: config saves silently drop bitcoin-rpcport, crash-looping lightningd until a full Stop/Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Settings **not** managed by StartOS (hardcoded):
 | Setting              | Value                   | Reason                                                                                                                     |
 | -------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `network`            | `bitcoin`               | Only mainnet supported                                                                                                     |
-| `bitcoin-rpcconnect` | bitcoind bridge address | Resolved to bitcoind's RPC over the LXC bridge; re-asserted into the config on every start by `main` (and on init by `watchHosts`) |
+| `bitcoin-rpcconnect` | bitcoind bridge address | Resolved to bitcoind's RPC over the LXC bridge; written by `watchHosts` and re-asserted by `main` on every start           |
 | `bitcoin-rpcport`    | bitcoind bridge port    | Dynamic — assigned by the bridge, not 8332; re-asserted alongside `bitcoin-rpcconnect`                                     |
 | `bitcoin-datadir`    | `/mnt/bitcoin`          | Mounted dependency volume                                                                                                  |
 | `clnrest-port`       | `3010`                  | Fixed internal port                                                                                                        |

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Settings **not** managed by StartOS (hardcoded):
 | Setting              | Value                   | Reason                                                                                                                     |
 | -------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `network`            | `bitcoin`               | Only mainnet supported                                                                                                     |
-| `bitcoin-rpcconnect` | bitcoind bridge address | Resolved to bitcoind's RPC over the LXC bridge                                                                             |
-| `bitcoin-rpcport`    | `8332`                  | bitcoind's RPC port over the bridge                                                                                        |
+| `bitcoin-rpcconnect` | bitcoind bridge address | Resolved to bitcoind's RPC over the LXC bridge; re-asserted into the config on every start by `main` (and on init by `watchHosts`) |
+| `bitcoin-rpcport`    | bitcoind bridge port    | Dynamic — assigned by the bridge, not 8332; re-asserted alongside `bitcoin-rpcconnect`                                     |
 | `bitcoin-datadir`    | `/mnt/bitcoin`          | Mounted dependency volume                                                                                                  |
 | `clnrest-port`       | `3010`                  | Fixed internal port                                                                                                        |
 | `clnrest-protocol`   | `http`                  | Plain HTTP inside the container; Tor onions serve it directly (Tor already encrypts) and StartOS adds SSL for LAN/clearnet |

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Settings **not** managed by StartOS (hardcoded):
 | Setting              | Value                   | Reason                                                                                                                     |
 | -------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `network`            | `bitcoin`               | Only mainnet supported                                                                                                     |
-| `bitcoin-rpcconnect` | bitcoind bridge address | Resolved to bitcoind's RPC over the LXC bridge; written by `watchHosts` and re-asserted by `main` on every start           |
-| `bitcoin-rpcport`    | bitcoind bridge port    | Dynamic — assigned by the bridge, not 8332; re-asserted alongside `bitcoin-rpcconnect`                                     |
+| `bitcoin-rpcconnect` | bitcoind bridge address | Resolved to bitcoind's RPC over the LXC bridge; written by `watchHosts`, which re-runs whenever the address changes        |
+| `bitcoin-rpcport`    | bitcoind bridge port    | Dynamic — assigned by the bridge, not 8332; written alongside `bitcoin-rpcconnect`                                        |
 | `bitcoin-datadir`    | `/mnt/bitcoin`          | Mounted dependency volume                                                                                                  |
 | `clnrest-port`       | `3010`                  | Fixed internal port                                                                                                        |
 | `clnrest-protocol`   | `http`                  | Plain HTTP inside the container; Tor onions serve it directly (Tor already encrypts) and StartOS adds SSL for LAN/clearnet |

--- a/startos/fileModels/config.ts
+++ b/startos/fileModels/config.ts
@@ -72,7 +72,7 @@ export const clbossZerobasefees = [
 export const shape = z.object({
   // Enforced by StartOS
   network: z.literal('bitcoin').catch('bitcoin'),
-  'bitcoin-rpcconnect': z.string().optional().catch(undefined),
+  'bitcoin-rpcconnect': iniString,
   'bitcoin-rpcport': iniNumber,
   'bitcoin-datadir': z.literal(bitcoinDataDir).catch(bitcoinDataDir),
   'bind-addr': z
@@ -377,8 +377,8 @@ function formToFile(
     // Enforced
     network: 'bitcoin' as const,
     // bitcoin-rpcconnect / bitcoin-rpcport come from `raw` (set to bitcoind's
-    // bridge address by watchHosts), preserved across config-action writes;
-    // absent until watchHosts resolves bitcoind's binding.
+    // bridge address by watchHosts and main), preserved across config-action
+    // writes; absent until bitcoind's binding resolves.
     'bitcoin-rpcconnect': raw?.['bitcoin-rpcconnect'],
     'bitcoin-rpcport': raw?.['bitcoin-rpcport'],
     'bitcoin-datadir': bitcoinDataDir,

--- a/startos/fileModels/config.ts
+++ b/startos/fileModels/config.ts
@@ -377,8 +377,8 @@ function formToFile(
     // Enforced
     network: 'bitcoin' as const,
     // bitcoin-rpcconnect / bitcoin-rpcport come from `raw` (set to bitcoind's
-    // bridge address by watchHosts and main), preserved across config-action
-    // writes; absent until bitcoind's binding resolves.
+    // bridge address by watchHosts), preserved across config-action writes;
+    // absent until bitcoind's binding resolves.
     'bitcoin-rpcconnect': raw?.['bitcoin-rpcconnect'],
     'bitcoin-rpcport': raw?.['bitcoin-rpcport'],
     'bitcoin-datadir': bitcoinDataDir,

--- a/startos/fileModels/config.ts
+++ b/startos/fileModels/config.ts
@@ -73,7 +73,7 @@ export const shape = z.object({
   // Enforced by StartOS
   network: z.literal('bitcoin').catch('bitcoin'),
   'bitcoin-rpcconnect': z.string().optional().catch(undefined),
-  'bitcoin-rpcport': z.number().optional().catch(undefined),
+  'bitcoin-rpcport': iniNumber,
   'bitcoin-datadir': z.literal(bitcoinDataDir).catch(bitcoinDataDir),
   'bind-addr': z
     .union([z.array(z.string()), z.string().transform((s) => [s])])

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -31,6 +31,25 @@ export const main = sdk.setupMain(async ({ effects }) => {
   // bitcoind's RPC over the bridge, for the sync-progress bitcoin-cli below.
   const bitcoind = await bitcoindRpcBridge(effects)
 
+  // Re-assert bitcoind's bridge address into the config file. watchHosts also
+  // writes these keys, but only on container init — a plain service restart
+  // skips init, so a config file that lost them (or went stale while CLN was
+  // stopped) would otherwise stay broken until the next full Stop/Start.
+  // merge() skips the write when the file already matches; when it does
+  // repair, the config const above restarts main once and the rerun no-ops.
+  if (bitcoind) {
+    await clnConfig.merge(
+      effects,
+      {
+        raw: {
+          'bitcoin-rpcconnect': bitcoind.host,
+          'bitcoin-rpcport': bitcoind.port,
+        },
+      },
+      { allowWriteAfterConst: true },
+    )
+  }
+
   // get store.json but don't watch for changes
   const store = await storeJson.read().once()
   if (!store) {

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -25,30 +25,25 @@ export const main = sdk.setupMain(async ({ effects }) => {
    */
   console.info(i18n('Starting Core Lightning!'))
 
-  // watch cln config for changes
-  const conf = await clnConfig.read().const(effects)
-
   // bitcoind's RPC over the bridge, for the sync-progress bitcoin-cli below.
   const bitcoind = await bitcoindRpcBridge(effects)
 
-  // Re-assert bitcoind's bridge address into the config file. watchHosts also
-  // writes these keys, but only on container init — a plain service restart
-  // skips init, so a config file that lost them (or went stale while CLN was
-  // stopped) would otherwise stay broken until the next full Stop/Start.
-  // merge() skips the write when the file already matches; when it does
-  // repair, the config const above restarts main once and the rerun no-ops.
+  // watchHosts writes these keys too, but init does not re-run on a plain start
+  // or restart, so a config that lost them — or went stale while CLN was
+  // stopped — would otherwise stay broken. merge() skips the write when the
+  // serialized file already matches, so this is a no-op on a healthy start. It
+  // must stay ahead of the const below, which would restart main on a repair.
   if (bitcoind) {
-    await clnConfig.merge(
-      effects,
-      {
-        raw: {
-          'bitcoin-rpcconnect': bitcoind.host,
-          'bitcoin-rpcport': bitcoind.port,
-        },
+    await clnConfig.merge(effects, {
+      raw: {
+        'bitcoin-rpcconnect': bitcoind.host,
+        'bitcoin-rpcport': bitcoind.port,
       },
-      { allowWriteAfterConst: true },
-    )
+    })
   }
+
+  // watch cln config for changes
+  const conf = await clnConfig.read().const(effects)
 
   // get store.json but don't watch for changes
   const store = await storeJson.read().once()

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -25,25 +25,11 @@ export const main = sdk.setupMain(async ({ effects }) => {
    */
   console.info(i18n('Starting Core Lightning!'))
 
-  // bitcoind's RPC over the bridge, for the sync-progress bitcoin-cli below.
-  const bitcoind = await bitcoindRpcBridge(effects)
-
-  // watchHosts writes these keys too, but init does not re-run on a plain start
-  // or restart, so a config that lost them — or went stale while CLN was
-  // stopped — would otherwise stay broken. merge() skips the write when the
-  // serialized file already matches, so this is a no-op on a healthy start. It
-  // must stay ahead of the const below, which would restart main on a repair.
-  if (bitcoind) {
-    await clnConfig.merge(effects, {
-      raw: {
-        'bitcoin-rpcconnect': bitcoind.host,
-        'bitcoin-rpcport': bitcoind.port,
-      },
-    })
-  }
-
   // watch cln config for changes
   const conf = await clnConfig.read().const(effects)
+
+  // bitcoind's RPC over the bridge, for the sync-progress bitcoin-cli below.
+  const bitcoind = await bitcoindRpcBridge(effects)
 
   // get store.json but don't watch for changes
   const store = await storeJson.read().once()

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -5,19 +5,19 @@ export const current = VersionInfo.of({
   releaseNotes: {
     en_US: `Fixes a bug that could disconnect Core Lightning from Bitcoin and leave it in a crash loop that restarting the service did not fix.
 
-Saving Core Lightning's settings could silently delete Bitcoin's RPC port from the generated configuration, leaving Core Lightning unable to reach Bitcoin. The port now survives every save, and Core Lightning re-checks Bitcoin's address each time it starts, so a broken configuration repairs itself.`,
+Saving Core Lightning's settings could silently delete Bitcoin's RPC port from the generated configuration, leaving Core Lightning unable to reach Bitcoin. The port now survives every save, and updating repairs a configuration that has already lost it.`,
     es_ES: `Corrige un error que podía desconectar Core Lightning de Bitcoin y dejarlo en un bucle de fallos que reiniciar el servicio no arreglaba.
 
-Guardar la configuración de Core Lightning podía borrar silenciosamente el puerto RPC de Bitcoin del archivo de configuración generado, dejando a Core Lightning sin poder conectar con Bitcoin. Ahora el puerto sobrevive a cada guardado, y Core Lightning vuelve a comprobar la dirección de Bitcoin en cada arranque, de modo que una configuración rota se repara sola.`,
+Guardar la configuración de Core Lightning podía borrar silenciosamente el puerto RPC de Bitcoin del archivo de configuración generado, dejando a Core Lightning sin poder conectar con Bitcoin. Ahora el puerto sobrevive a cada guardado, y actualizar repara una configuración que ya lo había perdido.`,
     de_DE: `Behebt einen Fehler, der Core Lightning von Bitcoin trennen und in einer Absturzschleife festhalten konnte, die ein Neustart des Dienstes nicht behob.
 
-Beim Speichern der Einstellungen von Core Lightning konnte der RPC-Port von Bitcoin stillschweigend aus der erzeugten Konfiguration gelöscht werden. Core Lightning erreichte Bitcoin dann nicht mehr. Der Port übersteht jetzt jedes Speichern, und Core Lightning prüft die Adresse von Bitcoin bei jedem Start erneut, sodass sich eine defekte Konfiguration selbst repariert.`,
+Beim Speichern der Einstellungen von Core Lightning konnte der RPC-Port von Bitcoin stillschweigend aus der erzeugten Konfiguration gelöscht werden. Core Lightning erreichte Bitcoin dann nicht mehr. Der Port übersteht jetzt jedes Speichern, und die Aktualisierung repariert eine Konfiguration, die ihn bereits verloren hat.`,
     pl_PL: `Naprawia błąd, który mógł odłączyć Core Lightning od Bitcoina i pozostawić go w pętli awarii, której restart usługi nie naprawiał.
 
-Zapisanie ustawień Core Lightning mogło po cichu usunąć port RPC Bitcoina z wygenerowanej konfiguracji, przez co Core Lightning nie mógł połączyć się z Bitcoinem. Port przetrwa teraz każdy zapis, a Core Lightning przy każdym starcie ponownie sprawdza adres Bitcoina, więc uszkodzona konfiguracja naprawia się sama.`,
+Zapisanie ustawień Core Lightning mogło po cichu usunąć port RPC Bitcoina z wygenerowanej konfiguracji, przez co Core Lightning nie mógł połączyć się z Bitcoinem. Port przetrwa teraz każdy zapis, a aktualizacja naprawia konfigurację, która już go utraciła.`,
     fr_FR: `Corrige un bogue qui pouvait déconnecter Core Lightning de Bitcoin et le laisser dans une boucle de plantage que le redémarrage du service ne corrigeait pas.
 
-Enregistrer les réglages de Core Lightning pouvait supprimer silencieusement le port RPC de Bitcoin du fichier de configuration généré, laissant Core Lightning incapable de joindre Bitcoin. Le port survit désormais à chaque enregistrement, et Core Lightning revérifie l'adresse de Bitcoin à chaque démarrage, de sorte qu'une configuration cassée se répare d'elle-même.`,
+Enregistrer les réglages de Core Lightning pouvait supprimer silencieusement le port RPC de Bitcoin du fichier de configuration généré, laissant Core Lightning incapable de joindre Bitcoin. Le port survit désormais à chaque enregistrement, et la mise à jour répare une configuration qui l'a déjà perdue.`,
   },
   migrations: {},
 })

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,21 +3,21 @@ import { VersionInfo } from '@start9labs/start-sdk'
 export const current = VersionInfo.of({
   version: '26.6.6:6',
   releaseNotes: {
-    en_US: `Fixes a bug that could disconnect Core Lightning from Bitcoin until a full Stop and Start.
+    en_US: `Fixes a bug that could disconnect Core Lightning from Bitcoin and leave it in a crash loop that restarting the service did not fix.
 
-Saving Core Lightning's settings could silently delete Bitcoin's RPC port from the generated configuration, leaving Core Lightning unable to reach Bitcoin and stuck in a crash loop that plain restarts never fixed. The port now survives every save, and Core Lightning re-checks Bitcoin's address each time it starts, so a broken configuration repairs itself.`,
-    es_ES: `Corrige un error que podía desconectar Core Lightning de Bitcoin hasta hacer un Stop y Start completos.
+Saving Core Lightning's settings could silently delete Bitcoin's RPC port from the generated configuration, leaving Core Lightning unable to reach Bitcoin. The port now survives every save, and Core Lightning re-checks Bitcoin's address each time it starts, so a broken configuration repairs itself.`,
+    es_ES: `Corrige un error que podía desconectar Core Lightning de Bitcoin y dejarlo en un bucle de fallos que reiniciar el servicio no arreglaba.
 
-Guardar la configuración de Core Lightning podía borrar silenciosamente el puerto RPC de Bitcoin del archivo de configuración generado, dejando a Core Lightning sin poder conectar con Bitcoin y atrapado en un bucle de fallos que los reinicios normales nunca arreglaban. Ahora el puerto sobrevive a cada guardado, y Core Lightning vuelve a comprobar la dirección de Bitcoin en cada arranque, de modo que una configuración rota se repara sola.`,
-    de_DE: `Behebt einen Fehler, der Core Lightning bis zu einem vollständigen Stop und Start von Bitcoin trennen konnte.
+Guardar la configuración de Core Lightning podía borrar silenciosamente el puerto RPC de Bitcoin del archivo de configuración generado, dejando a Core Lightning sin poder conectar con Bitcoin. Ahora el puerto sobrevive a cada guardado, y Core Lightning vuelve a comprobar la dirección de Bitcoin en cada arranque, de modo que una configuración rota se repara sola.`,
+    de_DE: `Behebt einen Fehler, der Core Lightning von Bitcoin trennen und in einer Absturzschleife festhalten konnte, die ein Neustart des Dienstes nicht behob.
 
-Beim Speichern der Einstellungen von Core Lightning konnte der RPC-Port von Bitcoin stillschweigend aus der erzeugten Konfiguration gelöscht werden. Core Lightning erreichte Bitcoin dann nicht mehr und hing in einer Absturzschleife fest, die gewöhnliche Neustarts nie behoben. Der Port übersteht jetzt jedes Speichern, und Core Lightning prüft die Adresse von Bitcoin bei jedem Start erneut, sodass sich eine defekte Konfiguration selbst repariert.`,
-    pl_PL: `Naprawia błąd, który mógł odłączyć Core Lightning od Bitcoina aż do pełnego zatrzymania i uruchomienia usługi.
+Beim Speichern der Einstellungen von Core Lightning konnte der RPC-Port von Bitcoin stillschweigend aus der erzeugten Konfiguration gelöscht werden. Core Lightning erreichte Bitcoin dann nicht mehr. Der Port übersteht jetzt jedes Speichern, und Core Lightning prüft die Adresse von Bitcoin bei jedem Start erneut, sodass sich eine defekte Konfiguration selbst repariert.`,
+    pl_PL: `Naprawia błąd, który mógł odłączyć Core Lightning od Bitcoina i pozostawić go w pętli awarii, której restart usługi nie naprawiał.
 
-Zapisanie ustawień Core Lightning mogło po cichu usunąć port RPC Bitcoina z wygenerowanej konfiguracji, przez co Core Lightning nie mógł połączyć się z Bitcoinem i tkwił w pętli awarii, której zwykłe restarty nigdy nie naprawiały. Port przetrwa teraz każdy zapis, a Core Lightning przy każdym starcie ponownie sprawdza adres Bitcoina, więc uszkodzona konfiguracja naprawia się sama.`,
-    fr_FR: `Corrige un bogue qui pouvait déconnecter Core Lightning de Bitcoin jusqu'à un Stop puis Start complets.
+Zapisanie ustawień Core Lightning mogło po cichu usunąć port RPC Bitcoina z wygenerowanej konfiguracji, przez co Core Lightning nie mógł połączyć się z Bitcoinem. Port przetrwa teraz każdy zapis, a Core Lightning przy każdym starcie ponownie sprawdza adres Bitcoina, więc uszkodzona konfiguracja naprawia się sama.`,
+    fr_FR: `Corrige un bogue qui pouvait déconnecter Core Lightning de Bitcoin et le laisser dans une boucle de plantage que le redémarrage du service ne corrigeait pas.
 
-Enregistrer les réglages de Core Lightning pouvait supprimer silencieusement le port RPC de Bitcoin du fichier de configuration généré, laissant Core Lightning incapable de joindre Bitcoin et bloqué dans une boucle de plantage que les redémarrages ordinaires ne corrigeaient jamais. Le port survit désormais à chaque enregistrement, et Core Lightning revérifie l'adresse de Bitcoin à chaque démarrage, de sorte qu'une configuration cassée se répare d'elle-même.`,
+Enregistrer les réglages de Core Lightning pouvait supprimer silencieusement le port RPC de Bitcoin du fichier de configuration généré, laissant Core Lightning incapable de joindre Bitcoin. Le port survit désormais à chaque enregistrement, et Core Lightning revérifie l'adresse de Bitcoin à chaque démarrage, de sorte qu'une configuration cassée se répare d'elle-même.`,
   },
   migrations: {},
 })

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,23 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '26.6.6:5',
+  version: '26.6.6:6',
   releaseNotes: {
-    en_US: `Adds a Custom External Host setting for announcing a tunnel or VPN endpoint, and renames "Other Config Options" to "General Settings".
+    en_US: `Fixes a bug that could disconnect Core Lightning from Bitcoin until a full Stop and Start.
 
-Enter an external endpoint — a Tunnelsats address, for example — and Core Lightning announces it in place of any public IP address StartOS detects, so peers are not handed the home IP the tunnel exists to hide. Your Tor address is still announced. The endpoint is not announced while Tor Only is enabled, because Core Lightning cannot resolve a hostname with every connection forced through the proxy.`,
-    es_ES: `Añade un ajuste Host Externo Personalizado para anunciar un túnel o punto final VPN, y renombra «Otras opciones de configuración» a «Configuración general».
+Saving Core Lightning's settings could silently delete Bitcoin's RPC port from the generated configuration, leaving Core Lightning unable to reach Bitcoin and stuck in a crash loop that plain restarts never fixed. The port now survives every save, and Core Lightning re-checks Bitcoin's address each time it starts, so a broken configuration repairs itself.`,
+    es_ES: `Corrige un error que podía desconectar Core Lightning de Bitcoin hasta hacer un Stop y Start completos.
 
-Introduzca un punto final externo — una dirección de Tunnelsats, por ejemplo — y Core Lightning lo anunciará en lugar de cualquier dirección IP pública que StartOS detecte, de modo que los pares no reciben la IP doméstica que el túnel existe para ocultar. Su dirección Tor se sigue anunciando. El punto final no se anuncia mientras Solo Tor esté activado, porque Core Lightning no puede resolver un nombre de host con todas las conexiones forzadas a través del proxy.`,
-    de_DE: `Fügt die Einstellung „Benutzerdefinierter externer Host“ hinzu, um einen Tunnel- oder VPN-Endpunkt bekannt zu geben, und benennt „Weitere Konfigurationsoptionen“ in „Allgemeine Einstellungen“ um.
+Guardar la configuración de Core Lightning podía borrar silenciosamente el puerto RPC de Bitcoin del archivo de configuración generado, dejando a Core Lightning sin poder conectar con Bitcoin y atrapado en un bucle de fallos que los reinicios normales nunca arreglaban. Ahora el puerto sobrevive a cada guardado, y Core Lightning vuelve a comprobar la dirección de Bitcoin en cada arranque, de modo que una configuración rota se repara sola.`,
+    de_DE: `Behebt einen Fehler, der Core Lightning bis zu einem vollständigen Stop und Start von Bitcoin trennen konnte.
 
-Geben Sie einen externen Endpunkt an — etwa eine Tunnelsats-Adresse — und Core Lightning gibt ihn anstelle jeder von StartOS erkannten öffentlichen IP-Adresse bekannt, sodass Peers nicht die Heim-IP erhalten, die der Tunnel verbergen soll. Ihre Tor-Adresse wird weiterhin bekannt gegeben. Solange „Nur Tor“ aktiviert ist, wird der Endpunkt nicht bekannt gegeben, denn Core Lightning kann keinen Hostnamen auflösen, wenn jede Verbindung über den Proxy erzwungen wird.`,
-    pl_PL: `Dodaje ustawienie Niestandardowy host zewnętrzny do ogłaszania tunelu lub punktu końcowego VPN oraz zmienia nazwę „Inne opcje konfiguracji” na „Ustawienia ogólne”.
+Beim Speichern der Einstellungen von Core Lightning konnte der RPC-Port von Bitcoin stillschweigend aus der erzeugten Konfiguration gelöscht werden. Core Lightning erreichte Bitcoin dann nicht mehr und hing in einer Absturzschleife fest, die gewöhnliche Neustarts nie behoben. Der Port übersteht jetzt jedes Speichern, und Core Lightning prüft die Adresse von Bitcoin bei jedem Start erneut, sodass sich eine defekte Konfiguration selbst repariert.`,
+    pl_PL: `Naprawia błąd, który mógł odłączyć Core Lightning od Bitcoina aż do pełnego zatrzymania i uruchomienia usługi.
 
-Podaj zewnętrzny punkt końcowy — na przykład adres Tunnelsats — a Core Lightning ogłosi go zamiast jakiegokolwiek publicznego adresu IP wykrytego przez StartOS, więc peery nie otrzymają domowego IP, które tunel ma ukrywać. Twój adres Tor jest nadal ogłaszany. Punkt końcowy nie jest ogłaszany, gdy włączona jest opcja Tylko Tor, ponieważ Core Lightning nie może rozwiązać nazwy hosta, gdy każde połączenie jest wymuszane przez proxy.`,
-    fr_FR: `Ajoute un réglage Hôte externe personnalisé pour annoncer un tunnel ou un point de terminaison VPN, et renomme « Autres options de configuration » en « Paramètres généraux ».
+Zapisanie ustawień Core Lightning mogło po cichu usunąć port RPC Bitcoina z wygenerowanej konfiguracji, przez co Core Lightning nie mógł połączyć się z Bitcoinem i tkwił w pętli awarii, której zwykłe restarty nigdy nie naprawiały. Port przetrwa teraz każdy zapis, a Core Lightning przy każdym starcie ponownie sprawdza adres Bitcoina, więc uszkodzona konfiguracja naprawia się sama.`,
+    fr_FR: `Corrige un bogue qui pouvait déconnecter Core Lightning de Bitcoin jusqu'à un Stop puis Start complets.
 
-Saisissez un point de terminaison externe — une adresse Tunnelsats, par exemple — et Core Lightning l'annonce à la place de toute adresse IP publique détectée par StartOS, afin que les pairs ne reçoivent pas l'IP domestique que le tunnel sert à masquer. Votre adresse Tor reste annoncée. Le point de terminaison n'est pas annoncé tant que Tor uniquement est activé, car Core Lightning ne peut pas résoudre un nom d'hôte lorsque chaque connexion est forcée par le proxy.`,
+Enregistrer les réglages de Core Lightning pouvait supprimer silencieusement le port RPC de Bitcoin du fichier de configuration généré, laissant Core Lightning incapable de joindre Bitcoin et bloqué dans une boucle de plantage que les redémarrages ordinaires ne corrigeaient jamais. Le port survit désormais à chaque enregistrement, et Core Lightning revérifie l'adresse de Bitcoin à chaque démarrage, de sorte qu'une configuration cassée se répare d'elle-même.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## The bug

`bitcoin-rpcport` is declared in the config file model as a raw `z.number()`, but `INI.parse` returns **strings**. Every read-modify-write of the config (any settings save, any plugin action) therefore failed to parse the port and `.catch(undefined)` silently deleted it. lightningd's `bcli` plugin, given `bitcoin-rpcconnect` but no `bitcoin-rpcport`, falls back to bitcoin-cli's default 8332 — where nothing listens, since the LXC bridge assigns a dynamic port — and lightningd exits fatally in a loop:

```
plugin-bcli: RPC connection timed out. Could not connect to bitcoind using bitcoin-cli.
The Bitcoin backend died.
Error: lightningd exited with code 1
```

Every other numeric key in the model already uses the `iniNumber` coercion helper that exists for exactly this; `bitcoin-rpcport` was the one exception — and the only raw-number key holding dynamic data, so the only one where the drop loses information (`bitcoin-rpcconnect` survives as a string, which is the asymmetric fingerprint we found in the field).

Introduced by the SDK 2.0 migration (#173), which changed the key from `z.literal(8332).catch(8332)` to `z.number().optional().catch(undefined)` and made `formToFile` read it from `raw`. Affects **26.6.6:0 through 26.6.6:5**.

**Compounding it:** the only other writer that restores the port is `watchHosts`, which runs on **init** — and init does not re-run on Start, Stop, or Restart. `control.rs`'s `start`/`stop`/`restart` only flip `DesiredStatus`, and the service actor answers with `rpc::Start`/`rpc::Stop` against the already-running container. `rpc::Init` is sent once, from `PersistentContainer::init` via `Service::new` — so on install, update, StartOS reboot, or a service reload. A user who hits this stays broken through unlimited restarts.

(`watchHosts` is not strictly one-shot: `setupInit` gives each handler a `constRetry` that re-runs it whenever one of its `.const()` inputs changes — the tor bridge address, peer addresses, `store.customExternalHosts`, `clnConfig['tor-only']`, or bitcoind's bridge address. Toggling Tor Only, for instance, would have healed an affected node incidentally.)

## The fix

1. **`config.ts`** — type `bitcoin-rpcport` with `iniNumber` like its siblings, and `bitcoin-rpcconnect` with `iniString`: it carries the same latent shape (a bare `z.string()` drops a duplicate-key array through `.catch(undefined)`) and was the one dynamic key in the enforced block still declared without a coercion helper. Optionality is unchanged — the address is dynamic and absent until bitcoind's binding resolves, never a placeholder.
2. **`main.ts`** — re-assert bitcoind's resolved bridge address into the config on **every start**, ahead of the config `.const()`. `FileHelper.merge` skips the write when the serialized file already matches, so this is a no-op on healthy starts; when it does repair a broken or stale file, the const reads the repaired content rather than a change it has to restart main for. Ordering it ahead of the const also removes the need for `allowWriteAfterConst`: the container runtime assigns a fresh `effects.constRetry = once(...)` on every `start()`, so no record in the FileHelper's `consts` matches this run when the merge runs.

An already-broken install self-heals — updating re-runs init and so `watchHosts`, and `main`'s merge covers plain restarts from then on.

Also corrects the README's config table, which claimed `bitcoin-rpcport` is `8332` — it is the dynamic bridge port; 8332 was only ever the accidental fallback this bug exposed.

## Verification

- `tsc --noEmit` and `prettier --check startos` clean; CI green on x86 and arm.
- Root cause reproduced against the repo's own `ini@5.0.0` and `zod@4.4.3`: `INI.parse` yields `bitcoin-rpcport` as a string, the old shape drops it while keeping `bitcoin-rpcconnect`, and re-serializing through `clnIniStringify` emits a config with `bitcoin-rpcconnect` and no `bitcoin-rpcport`. With `iniNumber` the port round-trips.
- `bcli` verified against CLN `v26.06.6`, the tag the Dockerfile pins: `gather_args` emits `-rpcport` only `if (bitcoind->rpcport)`, and both options register with a `NULL` default.
- Merge and const mechanics verified in start-sdk 2.0.9 (`FileHelper.merge`'s `if (toWrite !== fileDataRaw)` write-skip; `Watchable.const`'s `constRetry()`) and in the container runtime (`SystemForStartOs.start`).
- Lifecycle claims verified in start-core (`control.rs`, `service_actor.rs`, `persistent_container.rs`, `service_map.rs`).
- **Not yet exercised on a live install.**

## Test plan

1. Install this version on a server with Bitcoin installed and Core Lightning connected to it.
2. Confirm both keys are present: `start-cli package attach c-lightning -n lightning-sub -- cat /root/.lightning/config` should show `bitcoin-rpcconnect` and a `bitcoin-rpcport` matching bitcoind's bridge port — not 8332.
3. Open **General Settings**, change the alias, and save.
4. Re-read the config. `bitcoin-rpcport` must still be there. Before this fix it disappeared at this step.
5. Restart Core Lightning: health reaches *Synced*, and there is no `plugin-bcli: RPC connection timed out` in the logs.
6. Self-heal path — stop the service, delete the `bitcoin-rpcport` line from `/media/startos/data/package-data/volumes/c-lightning/data/main/config`, then start it. `main` re-adds the line and lightningd connects normally.

Follow-up PR planned for the restore path (preserve `emergency.recover`, address pregeneration, rescan prompt, rescan-flag robustness).
