### PR TITLE
feat: reliable fund recovery after restoring from backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,13 @@ settings are both set, and fails, so the drop is visible rather than silent.
 - `bitcoin/gossip_store` (rebuilt from peers on start)
 - `data/app/application-cln.log` (log file)
 
-**Restore behavior:** After restore, CLN runs `emergencyrecover` to attempt recovery of channel funds. Channel recovery depends on peer cooperation — funds may be stuck for an indeterminate period.
+**Restore behavior:** `setPostRestore` (backups.ts) snapshots the restored `emergency.recover` to `bitcoin/emergency.recover.restored-<date>` (CLN's chanbackup rewrites the live file as the old channels are processed and forgotten, so the snapshot is the last copy describing them), sets the one-shot `store.restore` flag, and raises an `important` task prompting the user to run Rescan Blockchain.
+
+On the next start, `main` consumes the flag to run three restore oneshots after `lightningd` is ready: `emergency-recover` (runs `lightning-cli emergencyrecover`; recovery depends on peer cooperation and channel funds may be stuck indefinitely), `address-pregen` (issues 10,000 `newaddr` calls so the fresh database's address-recognition window — `bip32_max_index + keyscan_gap`, where the gap is hardcoded to 50 upstream — covers every address the node's previous life used; without it a rescan silently misses wallet outputs), and `consume-flags`, which clears `store.rescan`/`store.restore` only once the others are done.
+
+10,000 is a heuristic sized from field data (a node whose web UIs were visited regularly burned ~140 indexes/day; its funds sat at indexes up to ~4,800 within five weeks of birth — UIs generate a fresh address per Receive view, used or not). A node that ran a busy UI for years can exceed it. The escape hatch, which locates funds at **any** depth without a rescan: `lightning-hsmtool dumponchaindescriptors <lightning-dir>/bitcoin/hsm_secret` prints the wallet's public descriptors (`.../0/0/*`); deriving addresses from them (or feeding them to `bitcoind`'s `scantxoutset`, which works on pruned nodes) pinpoints every funded index, after which `newaddr` to that depth plus one rescan recovers everything. Close payouts always sit at low indexes relative to the channel's era: CLN fixes the close-to address at channel *open* time.
+
+**Flag lifecycle:** `rescan` and `restore` are one-shot request flags in `store.json`. Setting one restarts a running service (the store const in `main` fires); main consumes them at startup but they are cleared only by `consume-flags` after `lightningd` answers RPC, so a request made while the service is crash-looping survives to the next successful start. The store const's custom equality ignores flag *clears* so that write doesn't bounce main; a mid-rescan crash resumes from the wallet's recorded height rather than re-running the scan, because the flag is already cleared moments after `lightningd` comes up.
 
 ## Health Checks
 

--- a/instructions.md
+++ b/instructions.md
@@ -44,13 +44,26 @@
 - **Watchtower Settings** — enable the TEOS watchtower server, enable the watchtower client, and add tower URIs to register with.
 - **Watchtower Info** — visible when the watchtower server is enabled; shows the server URI and stats.
 - **Watchtower Client Info** — visible when at least one tower is configured; shows registered towers and subscription state. Towers you add are registered automatically the next time Core Lightning starts, and stay registered across restarts and updates. If this list is empty, give the service a minute after startup and check it again — registration runs shortly after Core Lightning is up. Tower URIs are usually `.onion` addresses, which need Tor installed and running to reach.
-- **Rescan Blockchain** — rescan the blockchain from a given depth or block height. Useful after restoring an on-chain wallet.
+- **Rescan Blockchain** — rescan the blockchain from a given depth or block height. **Required after restoring from backup** — the wallet balance reads zero until a rescan completes.
 - **Reset UI Password** — clear the CLN Application UI password so you can set a new one on the next visit.
 - **Delete Gossip Store** — delete a corrupted `gossip_store`; CLN will rebuild it from peers on next start. Available when the service is stopped.
 
 ### Backups and restore
 
-StartOS backs up the `main` volume, excluding live database files and the gossip store. After a restore, CLN automatically runs `emergencyrecover` to attempt to recover channel funds via peer cooperation. Recovery is best-effort and depends on peers responding — once channels have resolved, sweep remaining funds to another wallet and reinstall fresh if you want to keep using the node.
+StartOS backs up the `main` volume, excluding live database files and the gossip store. Restoring brings back your keys and settings, but **not** the wallet's record of its own coins — so right after a restore, your on-chain balance reads **zero**. This is expected and your funds are not lost.
+
+After a restore, Core Lightning automatically:
+
+- runs `emergencyrecover` to attempt recovery of channel funds via peer cooperation (best-effort — it depends on peers responding),
+- pre-registers your wallet's addresses so the rescan below finds all of your coins,
+- saves an untouched copy of the channel-recovery file as `bitcoin/emergency.recover.restored-<date>` for support and manual recovery,
+- prompts you with a task to run **Rescan Blockchain**.
+
+Run the rescan with a blockheight from before your node was created, prefixed with a hyphen (e.g. `-800000`). It takes hours; the **Synced** health check stays red while it works — leave Core Lightning and Bitcoin running until it turns green, then check your balance.
+
+If the balance is still missing funds after the rescan completes, contact support: your funds are recoverable — the wallet's public descriptors can locate every coin exactly, even ones the rescan missed.
+
+Once any recovered channels have resolved, sweep remaining funds to another wallet and reinstall fresh if you want to keep using the node. Restore only what you must: restoring an old backup over a working node replaces its live records with stale ones.
 
 ## Limitations
 

--- a/startos/backups.ts
+++ b/startos/backups.ts
@@ -1,4 +1,7 @@
+import { copyFile } from 'fs/promises'
+import { rescanBlockchain } from './actions/rescanBlockchain'
 import { storeJson } from './fileModels/store.json'
+import { i18n } from './i18n'
 import { sdk } from './sdk'
 
 export const { createBackup, restoreInit } = sdk.setupBackups(
@@ -15,6 +18,27 @@ export const { createBackup, restoreInit } = sdk.setupBackups(
         ],
       })
       .setPostRestore(async (effects) => {
+        // CLN's chanbackup plugin keeps emergency.recover describing the
+        // CURRENT channel set, so once the restored node processes (and
+        // forgets) the old channels, it rewrites the file without them.
+        // Snapshot the restored copy first: it is the last file that can
+        // rebuild recovery stubs for the pre-backup channels (lightning-cli
+        // emergencyrecover / recoverchannel), and this copy is never touched.
+        const scb = '/media/startos/volumes/main/bitcoin/emergency.recover'
+        await copyFile(
+          scb,
+          `${scb}.restored-${new Date().toISOString().slice(0, 10)}`,
+        ).catch(() => {})
+
         await storeJson.merge(effects, { restore: true })
+
+        // A restored wallet database is empty: the balance reads zero until a
+        // blockchain rescan re-discovers the wallet's coins, and nothing else
+        // in the UI says so.
+        await sdk.action.createOwnTask(effects, rescanBlockchain, 'important', {
+          reason: i18n(
+            'After restoring from backup, your on-chain balance reads zero until the blockchain is rescanned. Run this action with a blockheight from before your node was first created, prefixed with a hyphen (for example -800000). The rescan takes hours; the Synced health check stays red while it works — leave Core Lightning and Bitcoin running until it turns green.',
+          ),
+        })
       }),
 )

--- a/startos/i18n/dictionaries/default.ts
+++ b/startos/i18n/dictionaries/default.ts
@@ -245,6 +245,7 @@ const dict = {
   'Must be a domain name, optionally followed by :port (e.g. example.com:9735).': 224,
   'Core Lightning resolves this name once at startup and announces the address it resolves to, so restart Core Lightning if the endpoint moves to a new address. It is not announced while Tor Only is on, because Core Lightning cannot resolve a hostname with every connection forced through the proxy.': 225,
   'Your custom external host is not being announced, because Core Lightning cannot resolve a hostname while Tor Only is enabled. In General Settings, either turn off Tor Only or clear the custom external host.': 226,
+  'After restoring from backup, your on-chain balance reads zero until the blockchain is rescanned. Run this action with a blockheight from before your node was first created, prefixed with a hyphen (for example -800000). The rescan takes hours; the Synced health check stays red while it works — leave Core Lightning and Bitcoin running until it turns green.': 227,
 } as const
 
 /**

--- a/startos/i18n/dictionaries/translations.ts
+++ b/startos/i18n/dictionaries/translations.ts
@@ -213,6 +213,7 @@ export default {
     224: 'Debe ser un nombre de dominio, opcionalmente seguido de :puerto (ej. example.com:9735).',
     225: 'Core Lightning resuelve este nombre una sola vez al arrancar y anuncia la dirección obtenida, así que reinicie Core Lightning si el punto final cambia de dirección. No se anuncia mientras Solo Tor esté activado, porque Core Lightning no puede resolver un nombre de host con todas las conexiones forzadas a través del proxy.',
     226: 'Su host externo personalizado no se está anunciando, porque Core Lightning no puede resolver un nombre de host mientras Solo Tor esté activado. En Configuración general, desactive Solo Tor o borre el host externo personalizado.',
+    227: 'Después de restaurar desde una copia de seguridad, su saldo on-chain marca cero hasta que se reescanee la blockchain. Ejecute esta acción con una altura de bloque anterior a la creación de su nodo, precedida de un guion (por ejemplo -800000). El reescaneo tarda horas; la comprobación de salud Sincronizado permanece en rojo mientras trabaja — deje Core Lightning y Bitcoin en ejecución hasta que vuelva a verde.',
   },
   de_DE: {
     0: 'Core Lightning wird gestartet!',
@@ -426,6 +427,7 @@ export default {
     224: 'Muss ein Domänenname sein, optional gefolgt von :Port (z. B. example.com:9735).',
     225: 'Core Lightning löst diesen Namen einmalig beim Start auf und gibt die ermittelte Adresse bekannt; starten Sie Core Lightning daher neu, wenn der Endpunkt seine Adresse wechselt. Solange „Nur Tor“ aktiviert ist, wird sie nicht bekannt gegeben, denn Core Lightning kann keinen Hostnamen auflösen, wenn jede Verbindung über den Proxy erzwungen wird.',
     226: 'Ihr benutzerdefinierter externer Host wird nicht bekannt gegeben, weil Core Lightning bei aktiviertem „Nur Tor“ keinen Hostnamen auflösen kann. Schalten Sie in den Allgemeinen Einstellungen entweder „Nur Tor“ aus oder leeren Sie den benutzerdefinierten externen Host.',
+    227: 'Nach dem Wiederherstellen aus einem Backup zeigt Ihr On-Chain-Guthaben null an, bis die Blockchain neu gescannt wurde. Führen Sie diese Aktion mit einer Blockhöhe von vor der Erstellung Ihres Nodes aus, mit vorangestelltem Bindestrich (zum Beispiel -800000). Der Rescan dauert Stunden; die Synchronisiert-Prüfung bleibt währenddessen rot — lassen Sie Core Lightning und Bitcoin laufen, bis sie wieder grün wird.',
   },
   pl_PL: {
     0: 'Uruchamianie Core Lightning!',
@@ -639,6 +641,7 @@ export default {
     224: 'Musi być nazwą domeny, opcjonalnie z portem :port (np. example.com:9735).',
     225: 'Core Lightning rozwiązuje tę nazwę jednorazowo przy starcie i ogłasza uzyskany adres, więc zrestartuj Core Lightning, jeśli punkt końcowy zmieni adres. Nie jest ogłaszany, gdy włączona jest opcja Tylko Tor, ponieważ Core Lightning nie może rozwiązać nazwy hosta, gdy każde połączenie jest wymuszane przez proxy.',
     226: 'Twój niestandardowy host zewnętrzny nie jest ogłaszany, ponieważ Core Lightning nie może rozwiązać nazwy hosta, gdy włączona jest opcja Tylko Tor. W Ustawieniach ogólnych wyłącz opcję Tylko Tor albo wyczyść niestandardowy host zewnętrzny.',
+    227: 'Po przywróceniu z kopii zapasowej saldo on-chain pokazuje zero, dopóki blockchain nie zostanie ponownie przeskanowany. Uruchom tę akcję z wysokością bloku sprzed utworzenia węzła, poprzedzoną myślnikiem (na przykład -800000). Ponowne skanowanie trwa godzinami; kontrola stanu Zsynchronizowano pozostaje w tym czasie czerwona — zostaw Core Lightning i Bitcoin uruchomione, aż znów będzie zielona.',
   },
   fr_FR: {
     0: 'Démarrage de Core Lightning !',
@@ -852,5 +855,6 @@ export default {
     224: 'Doit être un nom de domaine, optionnellement suivi de :port (ex. example.com:9735).',
     225: "Core Lightning résout ce nom une seule fois au démarrage et annonce l'adresse obtenue ; redémarrez donc Core Lightning si le point de terminaison change d'adresse. Elle n'est pas annoncée tant que Tor uniquement est activé, car Core Lightning ne peut pas résoudre un nom d'hôte lorsque chaque connexion est forcée par le proxy.",
     226: "Votre hôte externe personnalisé n'est pas annoncé, car Core Lightning ne peut pas résoudre un nom d'hôte tant que Tor uniquement est activé. Dans les Paramètres généraux, désactivez Tor uniquement ou effacez l'hôte externe personnalisé.",
+    227: "Après une restauration depuis une sauvegarde, votre solde on-chain affiche zéro jusqu'à ce que la blockchain soit rescannée. Lancez cette action avec une hauteur de bloc antérieure à la création de votre nœud, précédée d'un tiret (par exemple -800000). Le rescan prend des heures ; le contrôle Synchronisé reste rouge pendant ce temps — laissez Core Lightning et Bitcoin tourner jusqu'à ce qu'il redevienne vert.",
   },
 } satisfies Record<string, LangDict>

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -41,20 +41,18 @@ export const main = sdk.setupMain(async ({ effects }) => {
 
   if (store.rescan) {
     lightningdArgs.push(`--rescan=${store.rescan}`)
-    await storeJson.merge(effects, { rescan: undefined })
   }
 
-  // `restore` is a one-time trigger set by the post-restore backup hook (backups.ts).
-  // Clear it now — before the reactive store watch near the end of main — so the
-  // emergency-recover oneshot (lightning-cli emergencyrecover) and the "Backup
-  // Restoration Detected" health warning fire exactly once after a restore, not on
-  // every subsequent restart. The local `store.restore` snapshot read above still
-  // drives the oneshot this session; clearing only the on-disk value here mirrors how
-  // `rescan` is handled and keeps the clear ahead of the `.const` watch at line ~288,
-  // so it doesn't re-trigger main.
-  if (store.restore) {
-    await storeJson.merge(effects, { restore: undefined })
-  }
+  // `rescan` and `restore` are one-shot request flags (rescan set by the
+  // Rescan Blockchain action, restore by the post-restore hook in backups.ts).
+  // They are deliberately NOT cleared here: a session where lightningd never
+  // comes up must not consume them, or the user's request silently vanishes
+  // (a rescan requested during a crash loop used to be lost this way). The
+  // consume-flags oneshot at the end of the chain clears both once lightningd
+  // answers RPC — which happens early in a rescan, so a mid-scan crash still
+  // resumes from where it got to rather than re-running the whole scan. The
+  // store watch below ignores flag *clears*, so that write doesn't bounce
+  // main.
 
   /**
    * ======================== Daemons ========================
@@ -296,8 +294,26 @@ export const main = sdk.setupMain(async ({ effects }) => {
       requires: ['lightningd'],
     })
 
-  // restart on changes to store or config
-  await storeJson.read().const(effects)
+  // Restart on store changes that reconfigure the daemon chain (watchtower
+  // server/clients, custom external hosts) or on a NEW rescan/restore request
+  // — setting a flag is what restarts a running service so main can consume
+  // it. A rescan/restore transition back to undefined is the consume-flags
+  // oneshot clearing an already-consumed request, treated as equal so the
+  // clear doesn't restart the service. When main starts consuming another
+  // store field, add it to this comparison.
+  await storeJson
+    .read(
+      (s) => s,
+      (prev, next) =>
+        prev?.watchtowerServer === next?.watchtowerServer &&
+        JSON.stringify(prev?.watchtowerClients) ===
+          JSON.stringify(next?.watchtowerClients) &&
+        JSON.stringify(prev?.customExternalHosts) ===
+          JSON.stringify(next?.customExternalHosts) &&
+        (next?.rescan === undefined || prev?.rescan === next?.rescan) &&
+        (next?.restore === undefined || prev?.restore === next?.restore),
+    )
+    .const(effects)
 
   // emergency-recover and watchtower-server are added conditionally via thunks so
   // both can coexist in a single chain. (Previously each `if` rebuilt from
@@ -328,6 +344,56 @@ export const main = sdk.setupMain(async ({ effects }) => {
               },
             },
             requires: ['lightningd'],
+          }
+        : null,
+    )
+    .addOneshot('address-pregen', () =>
+      store.restore
+        ? {
+            subcontainer: lightningSub,
+            exec: {
+              // A restored database restarts the wallet's address counter at
+              // zero, and CLN only recognizes addresses up to 50 past the
+              // highest known-used index (keyscan_gap, hardcoded upstream).
+              // The node's previous life burned indexes far faster than
+              // on-chain hits advance that window — the web UIs issue a fresh
+              // address per Receive view, observed in the field at ~140/day
+              // (index 4,838 within five weeks of node birth) — so without
+              // this a post-restore rescan silently misses wallet outputs
+              // beyond the first >50-index gap. newaddr persists
+              // bip32_max_index, so pre-registering 10,000 addresses widens
+              // the window for every later rescan. (1,000 was field-tested
+              // and proven too shallow.)
+              command: [
+                'sh',
+                '-c',
+                `i=0; while [ $i -lt 10000 ]; do lightning-cli --lightning-dir=${rootDir} newaddr all > /dev/null || exit 1; i=$((i+1)); done`,
+              ],
+            },
+            requires: ['lightningd'],
+          }
+        : null,
+    )
+    .addOneshot('consume-flags', () =>
+      store.rescan || store.restore
+        ? {
+            subcontainer: lightningSub,
+            exec: {
+              fn: async () => {
+                // lightningd is up (and the restore oneshots above are done),
+                // so the request can no longer be lost to a failed start. The
+                // store watch in main ignores these clears, so this write
+                // doesn't restart the service.
+                await storeJson.merge(effects, {
+                  rescan: undefined,
+                  restore: undefined,
+                })
+                return null
+              },
+            },
+            requires: store.restore
+              ? ['lightningd', 'emergency-recover', 'address-pregen']
+              : ['lightningd'],
           }
         : null,
     )

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,21 +3,31 @@ import { VersionInfo } from '@start9labs/start-sdk'
 export const current = VersionInfo.of({
   version: '26.6.6:8',
   releaseNotes: {
-    en_US: `Lets the Watchtower Server address be offered on more of your network addresses.
+    en_US: `Makes restoring from a backup recover funds reliably.
 
-The service did not declare that watchtower connections secure themselves — the tower's identity key is part of the address you hand out, and everything sent to it is encrypted — so StartOS restricted where that address could be served. It is now declared correctly, matching how the Peer address already works.`,
-    es_ES: `Permite ofrecer la dirección del Servidor de Watchtower en más de tus direcciones de red.
+A restored node starts with an empty wallet database, and previously nothing said so: the balance read zero until a blockchain rescan, the rescan could silently miss older wallet addresses, and a rescan or restore requested while Core Lightning was failing to start was silently forgotten. After a restore, StartOS now prompts you to run Rescan Blockchain, pre-registers the wallet's first 10,000 addresses so the rescan finds everything, preserves a snapshot of the channel-recovery file (emergency.recover) before the node can rewrite it, and holds rescan/restore requests until Core Lightning has actually started.
 
-El servicio no declaraba que las conexiones de watchtower se protegen por sí solas — la clave de identidad de la torre forma parte de la dirección que compartes y todo lo que se le envía va cifrado —, por lo que StartOS restringía dónde podía servirse esa dirección. Ahora se declara correctamente, igual que ya funciona la dirección Peer.`,
-    de_DE: `Ermöglicht, die Adresse des Watchtower-Servers auf mehr Ihrer Netzwerkadressen anzubieten.
+Also lets the Watchtower Server address be offered on more of your network addresses. The service did not declare that watchtower connections secure themselves — the tower's identity key is part of the address you hand out, and everything sent to it is encrypted — so StartOS restricted where that address could be served.`,
+    es_ES: `Hace que restaurar desde una copia de seguridad recupere los fondos de forma fiable.
 
-Der Dienst gab nicht an, dass Watchtower-Verbindungen sich selbst absichern — der Identitätsschlüssel des Towers ist Teil der Adresse, die Sie weitergeben, und alles, was an ihn gesendet wird, ist verschlüsselt. Deshalb schränkte StartOS ein, wo diese Adresse bereitgestellt werden konnte. Sie wird jetzt korrekt deklariert, genau wie bereits die Peer-Adresse.`,
-    pl_PL: `Umożliwia udostępnianie adresu Serwera Watchtower na większej liczbie adresów sieciowych.
+Un nodo restaurado arranca con una base de datos de cartera vacía, y antes nada lo indicaba: el saldo marcaba cero hasta reescanear la blockchain, el reescaneo podía omitir silenciosamente direcciones antiguas de la cartera, y una petición de reescaneo o restauración hecha mientras Core Lightning no conseguía arrancar se olvidaba sin aviso. Tras una restauración, StartOS ahora le pide ejecutar Reescanear Blockchain, prerregistra las primeras 10.000 direcciones de la cartera para que el reescaneo lo encuentre todo, conserva una instantánea del archivo de recuperación de canales (emergency.recover) antes de que el nodo pueda reescribirlo, y retiene las peticiones de reescaneo/restauración hasta que Core Lightning haya arrancado de verdad.
 
-Usługa nie deklarowała, że połączenia watchtower zabezpieczają się same — klucz tożsamości wieży jest częścią udostępnianego adresu, a wszystko, co jest do niej wysyłane, jest szyfrowane — więc StartOS ograniczał, gdzie ten adres może być serwowany. Teraz jest deklarowany poprawnie, tak samo jak działa już adres Peer.`,
-    fr_FR: `Permet de proposer l'adresse du serveur Watchtower sur davantage de vos adresses réseau.
+Además, permite ofrecer la dirección del Servidor de Watchtower en más de tus direcciones de red. El servicio no declaraba que las conexiones de watchtower se protegen por sí solas — la clave de identidad de la torre forma parte de la dirección que compartes y todo lo que se le envía va cifrado —, por lo que StartOS restringía dónde podía servirse esa dirección.`,
+    de_DE: `Macht die Wiederherstellung aus einem Backup zuverlässig.
 
-Le service ne déclarait pas que les connexions watchtower se sécurisent elles-mêmes — la clé d'identité de la tour fait partie de l'adresse que vous partagez, et tout ce qui lui est envoyé est chiffré —, si bien que StartOS restreignait les endroits où cette adresse pouvait être servie. Elle est désormais déclarée correctement, comme l'est déjà l'adresse Peer.`,
+Ein wiederhergestellter Node startet mit einer leeren Wallet-Datenbank, und bisher wies nichts darauf hin: Das Guthaben zeigte bis zu einem Blockchain-Rescan null an, der Rescan konnte ältere Wallet-Adressen stillschweigend übersehen, und ein Rescan- oder Restore-Auftrag, der gestellt wurde, während Core Lightning nicht startete, ging stillschweigend verloren. Nach einer Wiederherstellung fordert StartOS Sie jetzt auf, Rescan Blockchain auszuführen, registriert die ersten 10.000 Wallet-Adressen vor, damit der Rescan alles findet, sichert einen Schnappschuss der Kanal-Wiederherstellungsdatei (emergency.recover), bevor der Node sie überschreiben kann, und hält Rescan-/Restore-Aufträge fest, bis Core Lightning tatsächlich gestartet ist.
+
+Außerdem kann die Adresse des Watchtower-Servers jetzt auf mehr Ihrer Netzwerkadressen angeboten werden. Der Dienst gab nicht an, dass Watchtower-Verbindungen sich selbst absichern — der Identitätsschlüssel des Towers ist Teil der Adresse, die Sie weitergeben, und alles, was an ihn gesendet wird, ist verschlüsselt. Deshalb schränkte StartOS ein, wo diese Adresse bereitgestellt werden konnte.`,
+    pl_PL: `Sprawia, że przywracanie z kopii zapasowej niezawodnie odzyskuje środki.
+
+Przywrócony węzeł startuje z pustą bazą portfela, a wcześniej nic o tym nie informowało: saldo pokazywało zero aż do ponownego przeskanowania blockchaina, skan mógł po cichu pominąć starsze adresy portfela, a żądanie skanu lub przywrócenia złożone, gdy Core Lightning nie mógł wystartować, było po cichu zapominane. Po przywróceniu StartOS prosi teraz o uruchomienie Rescan Blockchain, wstępnie rejestruje pierwsze 10 000 adresów portfela, aby skan znalazł wszystko, zachowuje migawkę pliku odzyskiwania kanałów (emergency.recover), zanim węzeł zdąży go nadpisać, i przechowuje żądania skanu/przywrócenia, dopóki Core Lightning faktycznie nie wystartuje.
+
+Ponadto adres Serwera Watchtower może być teraz udostępniany na większej liczbie adresów sieciowych. Usługa nie deklarowała, że połączenia watchtower zabezpieczają się same — klucz tożsamości wieży jest częścią udostępnianego adresu, a wszystko, co jest do niej wysyłane, jest szyfrowane — więc StartOS ograniczał, gdzie ten adres może być serwowany.`,
+    fr_FR: `Rend la restauration depuis une sauvegarde fiable pour récupérer les fonds.
+
+Un nœud restauré démarre avec une base de portefeuille vide, et rien ne le signalait auparavant : le solde affichait zéro jusqu'à un rescan de la blockchain, le rescan pouvait manquer silencieusement d'anciennes adresses du portefeuille, et une demande de rescan ou de restauration faite pendant que Core Lightning n'arrivait pas à démarrer était silencieusement oubliée. Après une restauration, StartOS vous invite désormais à lancer Rescan Blockchain, pré-enregistre les 10 000 premières adresses du portefeuille pour que le rescan trouve tout, conserve un instantané du fichier de récupération des canaux (emergency.recover) avant que le nœud ne puisse le réécrire, et retient les demandes de rescan/restauration jusqu'à ce que Core Lightning ait réellement démarré.
+
+Par ailleurs, l'adresse du serveur Watchtower peut désormais être proposée sur davantage de vos adresses réseau. Le service ne déclarait pas que les connexions watchtower se sécurisent elles-mêmes — la clé d'identité de la tour fait partie de l'adresse que vous partagez, et tout ce qui lui est envoyé est chiffré —, si bien que StartOS restreignait les endroits où cette adresse pouvait être servie.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
Builds on #181 (merged).

A restored node starts with an empty wallet database. Four gaps made that dangerous, all hit by a live support case in which a user restored a 9-month-old backup and saw zero balance with no explanation:

1. **Nothing said the balance would read zero** until a blockchain rescan. → `setPostRestore` now raises an `important` task prompting the Rescan Blockchain action, with instructions.
2. **The rescan silently missed wallet outputs.** CLN recognizes addresses only up to `bip32_max_index + keyscan_gap` (hardcoded 50), and a fresh database restarts the counter at zero — while web UIs and CLBOSS burn address indexes far faster than on-chain hits advance the window (field case: funds at indexes 1,793–4,838; CLBOSS burns ~1 per 10-minute swap attempt, reproduced live on a current install). → a post-restore oneshot pre-registers 10,000 addresses (`newaddr` persists the counter; 1,000 was field-tested and proven too shallow). The README documents the descriptor-based escape hatch for funds beyond any heuristic depth.
3. **`emergency.recover` was destroyed by the restore itself**: CLN's chanbackup rewrites it to describe the *current* (empty) channel set as the recovery stubs resolve, so the one file that could rebuild channel-recovery stubs was lost by the time anyone needed it (cost the field case 560,696 sats, now requiring manual reconstruction). → snapshot the restored copy to `emergency.recover.restored-<date>` before CLN starts.
4. **Rescan/restore requests were burned by failed starts**: `main` cleared the request flags immediately, so a rescan requested during a crash loop vanished (observed in the field). → flags are now cleared by a `consume-flags` oneshot only after lightningd answers RPC; the store watch's custom equality ignores flag *clears* so the consuming write doesn't restart the service, while flag *sets* still restart it (unchanged action UX). lightningd answers RPC early in a rescan, so a mid-scan crash still resumes rather than restarting the scan.

Verification: `tsc` clean; merge/const semantics verified against the SDK source (write-skip on identical content; explicit-undefined deletes keys); the pregen + rescan mechanism field-confirmed on the support case (funds recovered after pregen where two prior rescans found nothing). Not yet exercised end-to-end on a live restore — happy to hold for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)