### PR TITLE
fix: declare the watchtower server interface self-secured

### DIFF
--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -204,7 +204,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
         protocol: null,
         addSsl: null,
         preferredExternalPort: watchtowerPort,
-        secure: null,
+        secure: { ssl: false },
       },
     )
     const watchtower = sdk.createInterface(effects, {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,23 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '26.6.6:7',
+  version: '26.6.6:8',
   releaseNotes: {
-    en_US: `Fixes the Watchtower Client, which could not register with any watchtower and showed an empty list of towers.
+    en_US: `Lets the Watchtower Server address be offered on more of your network addresses.
 
-Two faults were responsible. The service image was missing the root certificates the watchtower client needs before it can make any network request, so every registration attempt failed immediately. Separately, the client's identity key and its list of registered towers were kept outside the service's permanent storage, so both were erased whenever the container was rebuilt. Watchtowers you have already added will register themselves again after this update.`,
-    es_ES: `Corrige el Cliente de Watchtower, que no lograba registrarse en ningún watchtower y mostraba una lista de torres vacía.
+The service did not declare that watchtower connections secure themselves — the tower's identity key is part of the address you hand out, and everything sent to it is encrypted — so StartOS restricted where that address could be served. It is now declared correctly, matching how the Peer address already works.`,
+    es_ES: `Permite ofrecer la dirección del Servidor de Watchtower en más de tus direcciones de red.
 
-Había dos fallos. A la imagen del servicio le faltaban los certificados raíz que el cliente de watchtower necesita antes de poder hacer cualquier petición de red, por lo que todos los intentos de registro fallaban de inmediato. Además, la clave de identidad del cliente y su lista de torres registradas se guardaban fuera del almacenamiento permanente del servicio, así que ambas se borraban cada vez que se reconstruía el contenedor. Los watchtowers que ya hayas añadido se registrarán de nuevo por sí solos tras esta actualización.`,
-    de_DE: `Behebt den Watchtower-Client, der sich bei keinem Watchtower registrieren konnte und eine leere Liste von Towers anzeigte.
+El servicio no declaraba que las conexiones de watchtower se protegen por sí solas — la clave de identidad de la torre forma parte de la dirección que compartes y todo lo que se le envía va cifrado —, por lo que StartOS restringía dónde podía servirse esa dirección. Ahora se declara correctamente, igual que ya funciona la dirección Peer.`,
+    de_DE: `Ermöglicht, die Adresse des Watchtower-Servers auf mehr Ihrer Netzwerkadressen anzubieten.
 
-Dafür waren zwei Fehler verantwortlich. Im Dienst-Image fehlten die Stammzertifikate, die der Watchtower-Client benötigt, bevor er überhaupt eine Netzwerkanfrage stellen kann, sodass jeder Registrierungsversuch sofort fehlschlug. Zusätzlich wurden der Identitätsschlüssel des Clients und seine Liste registrierter Towers außerhalb des dauerhaften Speichers des Dienstes abgelegt und daher bei jedem Neuaufbau des Containers gelöscht. Bereits hinzugefügte Watchtower registrieren sich nach dieser Aktualisierung von selbst erneut.`,
-    pl_PL: `Naprawia Klienta Watchtower, który nie mógł zarejestrować się w żadnym watchtowerze i pokazywał pustą listę wież.
+Der Dienst gab nicht an, dass Watchtower-Verbindungen sich selbst absichern — der Identitätsschlüssel des Towers ist Teil der Adresse, die Sie weitergeben, und alles, was an ihn gesendet wird, ist verschlüsselt. Deshalb schränkte StartOS ein, wo diese Adresse bereitgestellt werden konnte. Sie wird jetzt korrekt deklariert, genau wie bereits die Peer-Adresse.`,
+    pl_PL: `Umożliwia udostępnianie adresu Serwera Watchtower na większej liczbie adresów sieciowych.
 
-Odpowiadały za to dwa błędy. W obrazie usługi brakowało głównych certyfikatów, których klient watchtower potrzebuje, zanim wykona jakiekolwiek zapytanie sieciowe, więc każda próba rejestracji kończyła się natychmiastowym niepowodzeniem. Ponadto klucz tożsamości klienta i jego lista zarejestrowanych wież były przechowywane poza trwałym magazynem usługi, więc znikały przy każdej przebudowie kontenera. Watchtowery, które już zostały dodane, zarejestrują się ponownie samoczynnie po tej aktualizacji.`,
-    fr_FR: `Corrige le client Watchtower, qui ne parvenait à s'enregistrer auprès d'aucun watchtower et affichait une liste de tours vide.
+Usługa nie deklarowała, że połączenia watchtower zabezpieczają się same — klucz tożsamości wieży jest częścią udostępnianego adresu, a wszystko, co jest do niej wysyłane, jest szyfrowane — więc StartOS ograniczał, gdzie ten adres może być serwowany. Teraz jest deklarowany poprawnie, tak samo jak działa już adres Peer.`,
+    fr_FR: `Permet de proposer l'adresse du serveur Watchtower sur davantage de vos adresses réseau.
 
-Deux défauts en étaient responsables. L'image du service ne contenait pas les certificats racine dont le client watchtower a besoin avant de pouvoir effectuer la moindre requête réseau, si bien que chaque tentative d'enregistrement échouait immédiatement. Par ailleurs, la clé d'identité du client et sa liste de tours enregistrées étaient stockées en dehors du stockage permanent du service et étaient donc effacées à chaque reconstruction du conteneur. Les watchtowers que vous avez déjà ajoutés s'enregistreront à nouveau d'eux-mêmes après cette mise à jour.`,
+Le service ne déclarait pas que les connexions watchtower se sécurisent elles-mêmes — la clé d'identité de la tour fait partie de l'adresse que vous partagez, et tout ce qui lui est envoyé est chiffré —, si bien que StartOS restreignait les endroits où cette adresse pouvait être servie. Elle est désormais déclarée correctement, comme l'est déjà l'adresse Peer.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
The TEOS watchtower interface was bound declaring neither TLS nor pass-through:

```ts
await watchtowerMulti.bindPort(watchtowerPort, {
  protocol: null,
  addSsl: null,
  preferredExternalPort: watchtowerPort,
  secure: null,
})
```

In start-core, `secure` gates which gateways an address may be served on — with `None`, `net/host/mod.rs` filters down to gateways that are themselves secure:

```rust
let gateways = if opt.secure.is_some() { … } else { …filter(|g| g.secure()) }
```

teos secures itself and does not speak TLS: the `tower_id` in the URI a user hands out **is** the tower's secp256k1 pubkey, registration receipts are signed in both directions, and appointment blobs are encrypted with the dispute txid so the tower cannot read the penalty transaction until a breach occurs. That is exactly the `secure: { ssl: false }` shape — the same one the `peer` binding in this file already uses, and byte-for-byte what lnd-startos uses for its own watchtower binding.

`26.6.6:7` → `:8`.

## Verification

`tsc` and prettier clean. Built and installed on a dev box: the watchtower binding comes up enabled with a full nftables DNAT set to the container, and a watchtower client registered against that tower over its `.onion`, reporting `status: reachable` with a live subscription.

**Scope of what that proves:** the interface serves correctly with this change. I did not capture the pre-change DNAT state, so this PR rests on the declaration being *correct* — teos is self-secured, matching `peer` and lnd-startos — rather than on a measured before/after delta. The onion breakage originally chased here turned out to be an unrelated stale torrc entry, filed as Start9Labs/tor-startos#17.

## Test plan

1. Install this version.
2. **Actions → Watchtower Settings** → enable **Watchtower Server**; wait for the service to restart.
3. **Actions → Watchtower Info** → confirm a tower ID is shown and `Bitcoind Reachable: true`.
4. Add a **Tor address** to the **TEOS Watchtower** interface and confirm the address is offered.
5. On a CLN node (this one or another), **Watchtower Settings → Watchtower Client** → add `<tower_id>@<onion>:9814`.
6. Give it ~a minute after startup, then **Actions → Watchtower Client Info** → the tower should appear with `Status: reachable` and a subscription window.
