### PR TITLE
chore: bump CLBOSS to 0.16.1; 26.6.6:9 → 26.6.6:10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1577,9 +1577,9 @@
       "license": "MIT"
     },
     "node_modules/bitcoin-core-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#4f8dff85044df9c6ce1179f7a6090ee648c54ae8",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#eea170b29f5e39c813bd8ec6fd604b1f0dc10cad",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "diskusage": "^1.2.0",
         "tor-startos": "github:Start9Labs/tor-startos#next"
       }
@@ -1790,7 +1790,7 @@
       }
     },
     "node_modules/tor-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#e3e2b53a84cb92855ac7b35764df288fab1fa333",
+      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#aa867cfea0f20095feb56e96cad3510393d912de",
       "dependencies": {
         "@noble/curves": "*",
         "@start9labs/start-sdk": "2.0.7",

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,33 +1,48 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '26.6.6:9',
+  version: '26.6.6:10',
   releaseNotes: {
-    en_US: `Adds a **Revoke All Runes** action.
+    en_US: `Updates CLBOSS to 0.16.1.
 
-Runes are the credential apps use to authenticate to your node, and until now there was no way to take one back. The new action blacklists every rune this node has issued, so none of them work again; re-issue the ones you still need with Create Rune.
+CLBOSS is the plugin that manages your channels automatically. This point release fixes two failures it hit on Core Lightning 26.06:
 
-Run it if a rune may have been copied or exposed — or if an app with RPC access to your node may have created one without your knowledge. That applies if you run BTCPay Server, which reaches Core Lightning over its admin RPC socket and shipped an actively exploited vulnerability in versions before 2.4.2.`,
-    es_ES: `Añade una acción **Revocar todas las runas**.
+- A crash ("Unhandled exception in concurrent task! Incorrect type.") whenever a brand-new channel changed state.
+- Broken on-chain swaps: CLBOSS now asks explicitly for a taproot address instead of relying on a Core Lightning default that no longer exists. Previously the first swap failed and CLBOSS silently stopped swapping until the next restart.
 
-Las runas son la credencial con la que las aplicaciones se autentican ante tu nodo, y hasta ahora no había forma de retirar ninguna. La nueva acción incluye en la lista negra todas las runas emitidas por este nodo, de modo que ninguna vuelve a funcionar; vuelve a emitir las que sigas necesitando con «Crear runa».
+Full upstream notes: https://github.com/ZmnSCPxj/clboss/releases/tag/v0.16.1`,
+    es_ES: `Actualiza CLBOSS a la versión 0.16.1.
 
-Ejecútala si alguna runa pudo ser copiada o quedar expuesta, o si una aplicación con acceso RPC a tu nodo pudo crear una sin que lo supieras. Es el caso si usas BTCPay Server, que se comunica con Core Lightning por su socket RPC de administración y tuvo una vulnerabilidad explotada activamente en las versiones anteriores a la 2.4.2.`,
-    de_DE: `Fügt eine Aktion **Alle Runes widerrufen** hinzu.
+CLBOSS es el complemento que gestiona tus canales automáticamente. Esta versión de mantenimiento corrige dos fallos que se producían con Core Lightning 26.06:
 
-Runes sind die Zugangsdaten, mit denen sich Apps bei Ihrem Node authentifizieren, und bisher gab es keine Möglichkeit, eine zurückzuziehen. Die neue Aktion setzt jede von diesem Node ausgestellte Rune auf die Blacklist, sodass keine mehr funktioniert; stellen Sie die weiterhin benötigten mit „Rune erstellen“ neu aus.
+- Un cierre inesperado («Unhandled exception in concurrent task! Incorrect type.») cada vez que un canal recién creado cambiaba de estado.
+- Intercambios on-chain rotos: CLBOSS ahora solicita explícitamente una dirección taproot en lugar de depender de un valor predeterminado de Core Lightning que ya no existe. Antes, el primer intercambio fallaba y CLBOSS dejaba de hacer intercambios en silencio hasta el siguiente reinicio.
 
-Führen Sie sie aus, wenn eine Rune kopiert oder offengelegt worden sein könnte — oder wenn eine App mit RPC-Zugriff auf Ihren Node ohne Ihr Wissen eine erstellt haben könnte. Das betrifft Sie, wenn Sie BTCPay Server betreiben, das Core Lightning über dessen Admin-RPC-Socket erreicht und in Versionen vor 2.4.2 eine aktiv ausgenutzte Sicherheitslücke hatte.`,
-    pl_PL: `Dodaje akcję **Unieważnij wszystkie runy**.
+Notas completas del proyecto original: https://github.com/ZmnSCPxj/clboss/releases/tag/v0.16.1`,
+    de_DE: `Aktualisiert CLBOSS auf 0.16.1.
 
-Runy to poświadczenia, którymi aplikacje uwierzytelniają się w twoim węźle, a do tej pory nie było sposobu, aby którąś wycofać. Nowa akcja umieszcza na czarnej liście każdą runę wydaną przez ten węzeł, więc żadna nie działa ponownie; te, których nadal potrzebujesz, wydaj na nowo akcją „Utwórz runę”.
+CLBOSS ist das Plugin, das Ihre Kanäle automatisch verwaltet. Diese Wartungsversion behebt zwei Fehler, die unter Core Lightning 26.06 auftraten:
 
-Uruchom ją, jeśli któraś runa mogła zostać skopiowana lub ujawniona — albo jeśli aplikacja z dostępem RPC do twojego węzła mogła utworzyć runę bez twojej wiedzy. Dotyczy to sytuacji, gdy korzystasz z BTCPay Server, który łączy się z Core Lightning przez jego administracyjne gniazdo RPC i w wersjach starszych niż 2.4.2 zawierał aktywnie wykorzystywaną lukę.`,
-    fr_FR: `Ajoute une action **Révoquer toutes les runes**.
+- Ein Absturz („Unhandled exception in concurrent task! Incorrect type.“), sobald ein brandneuer Kanal seinen Zustand änderte.
+- Defekte On-Chain-Swaps: CLBOSS fordert jetzt ausdrücklich eine Taproot-Adresse an, statt sich auf eine nicht mehr vorhandene Core-Lightning-Voreinstellung zu verlassen. Zuvor schlug der erste Swap fehl und CLBOSS stellte die Swaps stillschweigend bis zum nächsten Neustart ein.
 
-Les runes sont l'identifiant avec lequel les applications s'authentifient auprès de votre nœud, et jusqu'ici rien ne permettait d'en retirer une. La nouvelle action met sur liste noire toutes les runes émises par ce nœud, si bien qu'aucune ne fonctionne plus ; réémettez celles dont vous avez encore besoin avec « Créer une rune ».
+Vollständige Hinweise des Upstream-Projekts: https://github.com/ZmnSCPxj/clboss/releases/tag/v0.16.1`,
+    pl_PL: `Aktualizuje CLBOSS do wersji 0.16.1.
 
-Lancez-la si une rune a pu être copiée ou exposée — ou si une application disposant d'un accès RPC à votre nœud a pu en créer une à votre insu. C'est le cas si vous utilisez BTCPay Server, qui atteint Core Lightning via son socket RPC d'administration et présentait une vulnérabilité activement exploitée dans les versions antérieures à 2.4.2.`,
+CLBOSS to wtyczka, która automatycznie zarządza twoimi kanałami. To wydanie poprawkowe naprawia dwa błędy występujące na Core Lightning 26.06:
+
+- Awarię („Unhandled exception in concurrent task! Incorrect type.”) za każdym razem, gdy zupełnie nowy kanał zmieniał stan.
+- Niedziałające swapy on-chain: CLBOSS prosi teraz wprost o adres taproot, zamiast polegać na domyślnym ustawieniu Core Lightning, które już nie istnieje. Wcześniej pierwszy swap kończył się niepowodzeniem, a CLBOSS po cichu przestawał wykonywać swapy aż do kolejnego restartu.
+
+Pełne informacje o wydaniu: https://github.com/ZmnSCPxj/clboss/releases/tag/v0.16.1`,
+    fr_FR: `Met à jour CLBOSS vers la version 0.16.1.
+
+CLBOSS est le plugin qui gère automatiquement vos canaux. Cette version corrective règle deux défaillances survenant avec Core Lightning 26.06 :
+
+- Un plantage (« Unhandled exception in concurrent task! Incorrect type. ») dès qu'un canal tout neuf changeait d'état.
+- Des échanges on-chain cassés : CLBOSS demande désormais explicitement une adresse taproot au lieu de s'appuyer sur une valeur par défaut de Core Lightning qui n'existe plus. Auparavant, le premier échange échouait et CLBOSS cessait silencieusement d'en effectuer jusqu'au redémarrage suivant.
+
+Notes complètes du projet amont : https://github.com/ZmnSCPxj/clboss/releases/tag/v0.16.1`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps CLBOSS from 0.16.0 to [0.16.1](https://github.com/ZmnSCPxj/clboss/releases/tag/v0.16.1) (released 2026-08-07) — a point release that exists specifically to fix two failures CLBOSS hits on Core Lightning 26.06, the version this package ships:

- **Crash on new channels.** `channel_state_changed` notifications for brand-new channels no longer carry `old_state` (deprecated in CLN v25.05, gone as of v26.06), which surfaced as `Unhandled exception in concurrent task! Incorrect type.` The handler now tolerates the missing field.
- **Swaps silently disabled.** `newaddr` no longer returns bech32 by default on newer CLN, so the first swap attempt failed and CLBOSS stopped attempting swaps until the next restart. It now requests `p2tr` explicitly.

StartOS version `26.6.6:9` → `26.6.6:10`. Registry currently has `26.6.6:9` published, so `:10` is free.

## Other upstreams checked, no move

| Component | Pinned | Latest available |
| --- | --- | --- |
| lightningd | `v26.06.6` | `v26.06.6` |
| cln-application (UI) | `26.04` | `v26.04` |
| sling | `v4.3.0` | `v4.3.0` |
| rust-teos | master commit `42db021` | newest release is `v0.2.0` (2023), which the pin is already 64 commits *ahead* of |
| plugins submodule | `b404933` | master has moved, but nothing in the `Dockerfile` or `startos/` consumes this submodule, so bumping it would not change the built image |
| `@start9labs/start-sdk` | `2.0.9` | `2.0.9` (npm latest) |

The `bitcoin-core-startos` and `tor-startos` git deps were re-resolved to their current `#next` heads; the lock stays at a single hoisted start-sdk copy.

## Test plan

- [x] `npm run check` green
- [ ] `make` builds an s9pk for `26.6.6:10`
- [ ] CLBOSS starts, and `clboss-status` no longer reports the `Incorrect type.` exception on a node that opens a new channel
